### PR TITLE
Issue #74 Ideal routing with an initial page DO NOT MERGE

### DIFF
--- a/src/application/constants.ts
+++ b/src/application/constants.ts
@@ -1,4 +1,4 @@
-export const SET_MAIN_TAB = 'ROUTER:SET_MAIN_TAB';
+export const SET_MAIN_PAGE = 'ROUTER:SET_MAIN_PAGE';
 
 export const SET_LOCALE = 'I18N:SET_LOCALE';
 

--- a/src/application/router.ts
+++ b/src/application/router.ts
@@ -3,13 +3,16 @@ import * as reduxFirstRouter from 'redux-first-router';
 import createMemoryHistory from 'history/createMemoryHistory';
 import * as constants from '../application/constants';
 import { Store as StoreForApplicationState } from '../stores';
+import { initialPage } from '../stores/page_switcher';
 
 const routesMap = {
-    [constants.SET_MAIN_TAB]: '/user/:mainPage',
+    [constants.SET_MAIN_PAGE]: '/page/:mainPage',
 };
 
 export const createStoreWithRouter = (reducerForApplicationState: Reducer<StoreForApplicationState>) => {
-    const history = createMemoryHistory();
+    const history = createMemoryHistory({
+        initialEntries: [routesMap[constants.SET_MAIN_PAGE].replace(':mainPage', String(initialPage))],
+    });
     const router = reduxFirstRouter.connectRoutes(history, routesMap);
     const rootReducer = combineReducers({ location: router.reducer, applicationState: reducerForApplicationState });
     return createStore(rootReducer, compose(router.enhancer, applyMiddleware(router.middleware)));

--- a/src/application/router.ts
+++ b/src/application/router.ts
@@ -3,10 +3,33 @@ import * as reduxFirstRouter from 'redux-first-router';
 import createMemoryHistory from 'history/createMemoryHistory';
 import * as constants from '../application/constants';
 import { Store as StoreForApplicationState } from '../stores';
-import { initialPage } from '../stores/page_switcher';
+import { Page, initialPage } from '../stores/page_switcher';
+
+
+const getPageFromRoute = (pageRoute: string): Page => {
+    switch (pageRoute) {
+        case 'questionnaire': return Page.Questionnaire;
+        case 'plan': return Page.MyPlan;
+        case 'explore': return Page.ExploreAll;
+        default: throw invalidPageRouteError(pageRoute);
+    }
+};
+
+const getRouteFromPage = (page: Page): string => {
+    switch (page) {
+        case Page.Questionnaire: return 'questionnaire';
+        case Page.MyPlan: return 'plan';
+        case Page.ExploreAll: return 'explore';
+        default: throw invalidPageError(page);
+    }
+};
 
 const routesMap = {
-    [constants.SET_MAIN_PAGE]: '/page/:mainPage',
+    [constants.SET_MAIN_PAGE]: {
+        path:'/page/:mainPage',
+        toPath: getRouteFromPage,
+        fromPath: getPageFromRoute
+    }
 };
 
 export const createStoreWithRouter = (reducerForApplicationState: Reducer<StoreForApplicationState>) => {
@@ -16,4 +39,14 @@ export const createStoreWithRouter = (reducerForApplicationState: Reducer<StoreF
     const router = reduxFirstRouter.connectRoutes(history, routesMap);
     const rootReducer = combineReducers({ location: router.reducer, applicationState: reducerForApplicationState });
     return createStore(rootReducer, compose(router.enhancer, applyMiddleware(router.middleware)));
+};
+
+const invalidPageRouteError = (pageRoute: string): Error => {
+    const message = `${pageRoute}: Invalid main page route, accepted values are "questionnaire", "plan", or "explore"`;
+    return new Error(message);
+};
+
+const invalidPageError = (page: Page): Error => {
+    const message = `${page}: Invalid main page, accepted values are Page.Questionnaire, Page.MyPlan, or Page.ExploreAll`;
+    return new Error(message);
 };

--- a/src/application/router.ts
+++ b/src/application/router.ts
@@ -11,7 +11,7 @@ const routesMap = {
 
 export const createStoreWithRouter = (reducerForApplicationState: Reducer<StoreForApplicationState>) => {
     const history = createMemoryHistory({
-        initialEntries: [routesMap[constants.SET_MAIN_PAGE].replace(':mainPage', String(initialPage))],
+        initialEntries: ['/page/' + initialPage],
     });
     const router = reduxFirstRouter.connectRoutes(history, routesMap);
     const rootReducer = combineReducers({ location: router.reducer, applicationState: reducerForApplicationState });

--- a/src/stores/__tests__/page_switcher.test.ts
+++ b/src/stores/__tests__/page_switcher.test.ts
@@ -9,15 +9,15 @@ const buildStore = (): pageSwitcher.Store => (
 );
 
 const buildStoreWithValue = (mainPage: pageSwitcher.Page): pageSwitcher.Store => {
-    const action = helpers.makeAction(constants.SET_MAIN_TAB, { mainPage });
+    const action = helpers.makeAction(constants.SET_MAIN_PAGE, { mainPage });
     return pageSwitcher.reducer(undefined, action);
 };
 
 describe('setting the main page', () => {
 
-    it('should create action with type SET_MAIN_TAB', () => {
+    it('should create action with type SET_MAIN_PAGE', () => {
         const theAction = pageSwitcher.setMainPage(pageSwitcher.Page.ExploreAll);
-        expect(theAction.type).toBe(constants.SET_MAIN_TAB);
+        expect(theAction.type).toBe(constants.SET_MAIN_PAGE);
     });
 
     it('should create action with page id as passed to the action creator', () => {
@@ -32,10 +32,10 @@ describe('the reducer', () => {
         expect(theStore.mainPage).toBe(pageSwitcher.Page.Questionnaire);
     });
 
-    it('when called with SET_MAIN_TAB should return store with value from action', () => {
+    it('when called with SET_MAIN_PAGE should return store with value from action', () => {
         const theStore = buildStore();
         const theAction = {
-            type: constants.SET_MAIN_TAB as typeof constants.SET_MAIN_TAB,
+            type: constants.SET_MAIN_PAGE as typeof constants.SET_MAIN_PAGE,
             payload: { mainPage: pageSwitcher.Page.MyPlan },
         };
         const theNewStore = pageSwitcher.reducer(theStore, theAction);
@@ -52,7 +52,7 @@ describe('the reducer', () => {
         const theStore = buildStore();
         const mainPageAsString = 'Page.MyPlan';
         const theAction = {
-            type: constants.SET_MAIN_TAB as typeof constants.SET_MAIN_TAB,
+            type: constants.SET_MAIN_PAGE as typeof constants.SET_MAIN_PAGE,
             payload: { mainPage: mainPageAsString },
         };
         const theNewStore = pageSwitcher.reducer(theStore, theAction);
@@ -63,7 +63,7 @@ describe('the reducer', () => {
         const theStore = buildStore();
         const invalidmainPageAsString = 'MainPage.Invalid';
         const theAction = {
-            type: constants.SET_MAIN_TAB as typeof constants.SET_MAIN_TAB,
+            type: constants.SET_MAIN_PAGE as typeof constants.SET_MAIN_PAGE,
             payload: { mainPage: invalidmainPageAsString },
         };
         expect(() => pageSwitcher.reducer(theStore, theAction)).toThrow(

--- a/src/stores/__tests__/page_switcher.test.ts
+++ b/src/stores/__tests__/page_switcher.test.ts
@@ -56,10 +56,9 @@ describe('the reducer', () => {
 
     it('should update the store if the payload contains a valid string', () => {
         const theStore = buildStore();
-        const mainPageAsString = 'plan';
         const theAction = {
             type: constants.SET_MAIN_PAGE as typeof constants.SET_MAIN_PAGE,
-            payload: { mainPage: mainPageAsString },
+            payload: { mainPage: pageSwitcher.Page.MyPlan },
         };
         const theNewStore = pageSwitcher.reducer(theStore, theAction);
         expect(theNewStore.mainPage).toBe(pageSwitcher.Page.MyPlan);
@@ -67,10 +66,9 @@ describe('the reducer', () => {
 
     it('should throw if the payload contains an invalid string', () => {
         const theStore = buildStore();
-        const invalidmainPageAsString = 'MainPage.Invalid';
         const theAction = {
             type: constants.SET_MAIN_PAGE as typeof constants.SET_MAIN_PAGE,
-            payload: { mainPage: invalidmainPageAsString },
+            payload: { mainPage: null as pageSwitcher.Page },
         };
         expect(() => pageSwitcher.reducer(theStore, theAction)).toThrow(
             /MainPage.Invalid: Invalid main page id, accepted values are "questionnaire", "plan", or "explore"/,

--- a/src/stores/__tests__/page_switcher.test.ts
+++ b/src/stores/__tests__/page_switcher.test.ts
@@ -13,6 +13,12 @@ const buildStoreWithValue = (mainPage: pageSwitcher.Page): pageSwitcher.Store =>
     return pageSwitcher.reducer(undefined, action);
 };
 
+describe('the initial page', () => {
+    it('should be set to Page.Questionnaire', () => {
+        expect(pageSwitcher.initialPage).toBe(pageSwitcher.Page.Questionnaire);
+    });
+});
+
 describe('setting the main page', () => {
 
     it('should create action with type SET_MAIN_PAGE', () => {
@@ -50,7 +56,7 @@ describe('the reducer', () => {
 
     it('should update the store if the payload contains a valid string', () => {
         const theStore = buildStore();
-        const mainPageAsString = 'Page.MyPlan';
+        const mainPageAsString = 'plan';
         const theAction = {
             type: constants.SET_MAIN_PAGE as typeof constants.SET_MAIN_PAGE,
             payload: { mainPage: mainPageAsString },
@@ -67,7 +73,7 @@ describe('the reducer', () => {
             payload: { mainPage: invalidmainPageAsString },
         };
         expect(() => pageSwitcher.reducer(theStore, theAction)).toThrow(
-            /MainPage.Invalid: Invalid main page id, accepted values are Page.Questionnaire, Page.MyPlan or Page.ExploreAll/,
+            /MainPage.Invalid: Invalid main page id, accepted values are "questionnaire", "plan", or "explore"/,
         );
     });
 });

--- a/src/stores/page_switcher.ts
+++ b/src/stores/page_switcher.ts
@@ -5,18 +5,20 @@ export enum Page {
     Questionnaire, MyPlan, ExploreAll,
 }
 
+export const initialPage = Page.Questionnaire;
+
 export type Store = Readonly<ReturnType<typeof buildDefaultStore>>;
 
 export type SetMainPageAction = Readonly<ReturnType<typeof setMainPage>>;
 
 // tslint:disable-next-line:typedef
 export const setMainPage = (mainPage: Page | string) => (
-    helpers.makeAction(constants.SET_MAIN_TAB, { mainPage })
+    helpers.makeAction(constants.SET_MAIN_PAGE, { mainPage })
 );
 
 // tslint:disable-next-line:typedef
 const buildDefaultStore = () => (
-    { mainPage: Page.Questionnaire }
+    { mainPage: initialPage }
 );
 
 export const reducer = (store: Store = buildDefaultStore(), action?: SetMainPageAction): Store => {
@@ -24,14 +26,14 @@ export const reducer = (store: Store = buildDefaultStore(), action?: SetMainPage
         return store;
     }
     switch (action.type) {
-        case constants.SET_MAIN_TAB:
+        case constants.SET_MAIN_PAGE:
             return { ...store, mainPage: validateMainPageId(action.payload.mainPage) };
         default:
             return store;
     }
 };
 
-// Using number as a type alias for the MainPage enum, see
+// Using number as a type alias for the Page enum, see
 // https://stackoverflow.com/questions/29706609/typescript-how-to-add-type-guards-for-enums-in-union-types/29706830#29706830
 
 const validateMainPageId = (pageId: number | string): Page => (

--- a/src/stores/page_switcher.ts
+++ b/src/stores/page_switcher.ts
@@ -37,9 +37,9 @@ export const reducer = (store: Store = buildDefaultStore(), action?: SetMainPage
 
 const getPageFromString = (pageId: string): Page => {
     switch (pageId) {
-        case 'questionnaire': return Page.Questionnaire;
-        case 'plan': return Page.MyPlan;
-        case 'explore': return Page.ExploreAll;
+        case Page.Questionnaire: return Page.Questionnaire;
+        case Page.MyPlan: return Page.MyPlan;
+        case Page.ExploreAll: return Page.ExploreAll;
         default: throw invalidPageIdError(pageId);
     }
 };

--- a/src/stores/page_switcher.ts
+++ b/src/stores/page_switcher.ts
@@ -7,11 +7,11 @@ export enum Page {
     ExploreAll = 'explore',
 }
 
-export const initialPage = Page.Questionnaire;
-
 export type Store = Readonly<ReturnType<typeof buildDefaultStore>>;
 
 export type SetMainPageAction = Readonly<ReturnType<typeof setMainPage>>;
+
+export const initialPage = Page.Questionnaire;
 
 // tslint:disable-next-line:typedef
 export const setMainPage = (mainPage: Page | string) => (

--- a/src/stores/page_switcher.ts
+++ b/src/stores/page_switcher.ts
@@ -2,9 +2,9 @@ import * as constants from '../application/constants';
 import * as helpers from './helpers/make_action';
 
 export enum Page {
-    Questionnaire = 'questionnaire',
-    MyPlan = 'plan',
-    ExploreAll = 'explore',
+    Questionnaire,
+    MyPlan,
+    ExploreAll,
 }
 
 export type Store = Readonly<ReturnType<typeof buildDefaultStore>>;
@@ -14,7 +14,7 @@ export type SetMainPageAction = Readonly<ReturnType<typeof setMainPage>>;
 export const initialPage = Page.Questionnaire;
 
 // tslint:disable-next-line:typedef
-export const setMainPage = (mainPage: Page | string) => (
+export const setMainPage = (mainPage: Page) => (
     helpers.makeAction(constants.SET_MAIN_PAGE, { mainPage })
 );
 
@@ -29,22 +29,8 @@ export const reducer = (store: Store = buildDefaultStore(), action?: SetMainPage
     }
     switch (action.type) {
         case constants.SET_MAIN_PAGE:
-            return { ...store, mainPage: getPageFromString(action.payload.mainPage) };
+            return { ...store, mainPage: action.payload.mainPage };
         default:
             return store;
     }
-};
-
-const getPageFromString = (pageId: string): Page => {
-    switch (pageId) {
-        case Page.Questionnaire: return Page.Questionnaire;
-        case Page.MyPlan: return Page.MyPlan;
-        case Page.ExploreAll: return Page.ExploreAll;
-        default: throw invalidPageIdError(pageId);
-    }
-};
-
-const invalidPageIdError = (pageId: string): Error => {
-    const message = `${pageId}: Invalid main page id, accepted values are "questionnaire", "plan", or "explore"`;
-    return new Error(message);
 };

--- a/src/stores/page_switcher.ts
+++ b/src/stores/page_switcher.ts
@@ -2,7 +2,9 @@ import * as constants from '../application/constants';
 import * as helpers from './helpers/make_action';
 
 export enum Page {
-    Questionnaire, MyPlan, ExploreAll,
+    Questionnaire = 'questionnaire',
+    MyPlan = 'plan',
+    ExploreAll = 'explore',
 }
 
 export const initialPage = Page.Questionnaire;
@@ -27,29 +29,22 @@ export const reducer = (store: Store = buildDefaultStore(), action?: SetMainPage
     }
     switch (action.type) {
         case constants.SET_MAIN_PAGE:
-            return { ...store, mainPage: validateMainPageId(action.payload.mainPage) };
+            return { ...store, mainPage: getPageFromString(action.payload.mainPage) };
         default:
             return store;
     }
 };
 
-// Using number as a type alias for the Page enum, see
-// https://stackoverflow.com/questions/29706609/typescript-how-to-add-type-guards-for-enums-in-union-types/29706830#29706830
-
-const validateMainPageId = (pageId: number | string): Page => (
-    typeof pageId === 'string' ? toMainPageId(pageId) : pageId
-);
-
-const toMainPageId = (pageId: string): Page => {
+const getPageFromString = (pageId: string): Page => {
     switch (pageId) {
-        case 'Page.Questionnaire': return Page.Questionnaire;
-        case 'Page.MyPlan': return Page.MyPlan;
-        case 'Page.ExploreAll': return Page.ExploreAll;
+        case 'questionnaire': return Page.Questionnaire;
+        case 'plan': return Page.MyPlan;
+        case 'explore': return Page.ExploreAll;
         default: throw invalidPageIdError(pageId);
     }
 };
 
 const invalidPageIdError = (pageId: string): Error => {
-    const message = `${pageId}: Invalid main page id, accepted values are Page.Questionnaire, Page.MyPlan or Page.ExploreAll`;
+    const message = `${pageId}: Invalid main page id, accepted values are "questionnaire", "plan", or "explore"`;
     return new Error(message);
 };


### PR DESCRIPTION
# DO NOT MERGE

@rasmus-storjohann-PG 
Based on your feedback and also what I've learned about the redux-first-router, this is what I think would be the most elegant solution. The theory being that whenever `SET_MAIN_PAGE` is called (whether by the links in the footer or by the Back button) then it will set the `mainPage` to a value from the `Page` enum. If that were so, then we'd have the mapping between the `string` used in the route to the `Page` used in the Action defined by the `toPath` and `fromPath` functions in `router.ts`. 

However, when I try to compile, I get this error message:
```
src/application/router.ts(39,60): error TS2345: Argument of type '{ [constants.SET_MAIN_PAGE]: { path: string; toPath: (page: Page) => string; fromPath: (pageRoute...' is not assignable to parameter of type 'RoutesMap<{ path
: string; toPath: (page: Page) => string; fromPath: (pageRoute: string) => Page; ...'.
  Property '[constants.SET_MAIN_PAGE]' is incompatible with index signature.
    Type '{ path: string; toPath: (page: Page) => string; fromPath: (pageRoute: string) => Page; }' is not assignable to type 'Route<{ path: string; toPath: (page: Page) => string; fromPath: (pageRoute: string) => Page; }, a
...'.
      Type '{ path: string; toPath: (page: Page) => string; fromPath: (pageRoute: string) => Page; }' is not assignable to type 'RouteObject<{ path: string; toPath: (page: Page) => string; fromPath: (pageRoute: string) => Pa
ge...'.
        Type '{ path: string; toPath: (page: Page) => string; fromPath: (pageRoute: string) => Page; }' is not assignable to type '{ capitalizedWords?: boolean; navKey?: string; path: string; thunk?: RouteThunk<any>; fromPat
h?(p...'.
          Types of property 'fromPath' are incompatible.
            Type '(pageRoute: string) => Page' is not assignable to type '(path: string, key?: string) => string'.
              Type 'Page' is not assignable to type 'string'.
```

I believe that it's telling me that the type signature of `toPath` and `fromPath` must be `(string) => string` whereas mine are `(string) => Page` and `(Page) => string`. Is there any way around this in Typescript?

If I don't use the `toPath` and `fromPath` methods, then the router just calls `toString()` on the enum values as they come into the path and then supplies them as `string` values when putting it back into the `mainPage` payload of the `SET_MAIN_PAGE` action when you use the Back button.

If you have time after sprint planning tomorrow, I'd love to talk this over.

(Note, since it's not compiling, I didn't bother to update the tests again to reflect these changes.)