### PR TITLE
Issue #69 Fix devtools server config

### DIFF
--- a/bin/postinstall.sh
+++ b/bin/postinstall.sh
@@ -10,4 +10,3 @@
 # https://github.com/aws/aws-sdk-js/issues/1926
 
 sed -i -e "s/\(^declare var require: NodeRequire;\)/\/\/\1/g" node_modules/\@types/node/index.d.ts
-yarn remotedev-debugger --hostname localhost --port 5678 --injectserver

--- a/package-lock.json
+++ b/package-lock.json
@@ -1167,6 +1167,15 @@
         "@types/redux-first-router": "*"
       }
     },
+    "@types/remote-redux-devtools": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@types/remote-redux-devtools/-/remote-redux-devtools-0.5.2.tgz",
+      "integrity": "sha512-QbXwLYwM3cgkm5y6sT23eDloF0NverqgzI9V0lFSNWFdfl4rkdNroCJ8t3Z9pYnMShwNgOa9/npY3exFl+8IgA==",
+      "dev": true,
+      "requires": {
+        "redux": "^3.6.0"
+      }
+    },
     "@types/uuid": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.3.tgz",
@@ -2763,12 +2772,6 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
       "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
     },
-    "base64id": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
-      "integrity": "sha1-As4P3u4M709ACA4ec+g08LG/zj8=",
-      "dev": true
-    },
     "base64url": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
@@ -3582,16 +3585,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "cors": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
-      "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
-      "dev": true,
-      "requires": {
-        "object-assign": "^4",
-        "vary": "^1"
-      }
     },
     "cpx": {
       "version": "1.5.0",
@@ -4717,12 +4710,6 @@
         }
       }
     },
-    "expirymanager": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/expirymanager/-/expirymanager-0.9.3.tgz",
-      "integrity": "sha1-5fazugDY12z2MxHCtx19/JvePk8=",
-      "dev": true
-    },
     "expo": {
       "version": "27.0.1",
       "resolved": "https://registry.npmjs.org/expo/-/expo-27.0.1.tgz",
@@ -5083,12 +5070,6 @@
       "requires": {
         "locate-path": "^2.0.0"
       }
-    },
-    "fleximap": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/fleximap/-/fleximap-0.9.10.tgz",
-      "integrity": "sha1-GqUP9qj+oAN8w3jjjdrMCRAlrBA=",
-      "dev": true
     },
     "follow-redirects": {
       "version": "1.4.1",
@@ -5777,12 +5758,6 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
-    },
-    "getport": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/getport/-/getport-0.1.0.tgz",
-      "integrity": "sha1-q93z1dHnfdlnzPorA2oKH7Jv1/c=",
-      "dev": true
     },
     "glob": {
       "version": "7.1.2",
@@ -8016,12 +7991,6 @@
       "integrity": "sha1-uEF7dQZho5K+4sJTfGiyqdSXfNU=",
       "dev": true
     },
-    "js-data": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/js-data/-/js-data-2.10.1.tgz",
-      "integrity": "sha512-rR+ijfHD/esOVgJsafvELHvdoQKUbQaojVM+w3DmIeq7Hc7QZZp0CeF+jhKXbHWdHJFWTNNRza1Kp4AzKnEaTg==",
-      "dev": true
-    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -8352,12 +8321,6 @@
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.10.tgz",
       "integrity": "sha512-iesFYPmxYYGTcmQK0sL8bX3TGHyM6b2qREaB4kamHfQyfPJP0xgoGxp19nsH16nsfquLdiyKyX3mQkfiSGV8Rg=="
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
@@ -9341,15 +9304,6 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "ncom": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ncom/-/ncom-1.0.1.tgz",
-      "integrity": "sha512-g7/hfG/yYNoi4GMwiyW1F17KFcDhgQ7YLOe+889sfaS+D4G9qcpLvtQu7FY5diDa6K+mLNU7tdhy5KD5t68ByQ==",
-      "dev": true,
-      "requires": {
-        "sc-formatter": "~3.0.1"
-      }
-    },
     "ncp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
@@ -9414,12 +9368,6 @@
         "shellwords": "^0.1.1",
         "which": "^1.3.0"
       }
-    },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
-      "dev": true
     },
     "nomnom": {
       "version": "1.6.2",
@@ -9809,12 +9757,6 @@
         "macos-release": "^1.0.0",
         "win-release": "^1.0.0"
       }
-    },
-    "os-shim": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
-      "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=",
-      "dev": true
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -11341,49 +11283,6 @@
         "socketcluster-client": "^5.3.1"
       }
     },
-    "remotedev-rn-debugger": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/remotedev-rn-debugger/-/remotedev-rn-debugger-0.8.3.tgz",
-      "integrity": "sha512-Ie1ciAbzbXjx603AfnmID73TfI4OdmtDFzTDVAs6kdm+3K22v5Mj2kKTXyYPK3NOD7FD7l75mksIp021zDikwA==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.0.1",
-        "minimist": "^1.2.0",
-        "remotedev-server": "^0.2.4",
-        "semver": "^5.4.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
     "remotedev-serialize": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/remotedev-serialize/-/remotedev-serialize-0.1.1.tgz",
@@ -11393,35 +11292,12 @@
         "jsan": "^3.1.9"
       }
     },
-    "remotedev-server": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/remotedev-server/-/remotedev-server-0.2.4.tgz",
-      "integrity": "sha1-sBmwFRMgZM12Aky5HrAmgB8kzWc=",
-      "dev": true,
-      "requires": {
-        "body-parser": "^1.15.0",
-        "chalk": "^1.1.3",
-        "cors": "^2.7.1",
-        "ejs": "^2.4.1",
-        "express": "^4.13.3",
-        "getport": "^0.1.0",
-        "js-data": "^2.9.0",
-        "lodash": "^4.15.0",
-        "minimist": "^1.2.0",
-        "node-uuid": "^1.4.0",
-        "object-assign": "^4.0.0",
-        "repeat-string": "^1.5.4",
-        "semver": "^5.3.0",
-        "socketcluster": "^6.7.1"
-      }
-    },
     "remotedev-utils": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/remotedev-utils/-/remotedev-utils-0.1.4.tgz",
       "integrity": "sha1-ZDcAgZqUNngHPHXrGF6B2WYgs0g=",
       "dev": true,
       "requires": {
-        "get-params": "^0.1.2",
         "jsan": "^3.1.5",
         "lodash": "^4.0.0",
         "remotedev-serialize": "^0.1.0",
@@ -11660,12 +11536,6 @@
       "requires": {
         "is-promise": "^2.1.0"
       }
-    },
-    "rx": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
-      "dev": true
     },
     "rx-lite": {
       "version": "4.0.8",
@@ -12012,78 +11882,6 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.6.tgz",
       "integrity": "sha1-XWFr6KXmB9VOEUr65Vt+ry/MMkA="
     },
-    "sc-auth": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/sc-auth/-/sc-auth-4.1.3.tgz",
-      "integrity": "sha512-qNXHiEnc4u7R0uSDtXIuUa9jqfsRB4UTHIo4Sx4+P6TZ3skPM6P6QVFkM8/E5bVls5/9LSGudIAqkTG3ZQ6rdg==",
-      "dev": true,
-      "requires": {
-        "sc-errors": "^1.4.0",
-        "sc-jsonwebtoken": "^7.4.2"
-      },
-      "dependencies": {
-        "sc-errors": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/sc-errors/-/sc-errors-1.4.0.tgz",
-          "integrity": "sha512-h+jRWx/xRJmkPFDd0IltoTl/QJ6hAr5Y+3ZVeBQRLuWZKe+dHdf2uVwFp2OYqlLQ7GHht4y9eXG2zOf2Ik6PTw==",
-          "dev": true
-        }
-      }
-    },
-    "sc-broker": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/sc-broker/-/sc-broker-4.1.1.tgz",
-      "integrity": "sha512-twYjsHkvl3RNtSXpSWbFPiDXY+zB/Wiw+motXnVnxV502GlrZzRw0uotR+Is0U+ErhlimyhpMpPZTY7QDa+Qqw==",
-      "dev": true,
-      "requires": {
-        "expirymanager": "~0.9.3",
-        "fleximap": "~0.9.10",
-        "ncom": "~1.0.1",
-        "sc-errors": "~1.3.3",
-        "uuid": "3.1.0"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
-          "dev": true
-        }
-      }
-    },
-    "sc-broker-cluster": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/sc-broker-cluster/-/sc-broker-cluster-4.3.1.tgz",
-      "integrity": "sha512-YvGJJcIeuotbBqa70XaTcJe1Xw7YZ9t7f4YN37X6Ah71osvr0PVO9v3MWYIZPyzbBdTDe1u7/6JbuEw0Uqq1nA==",
-      "dev": true,
-      "requires": {
-        "async": "2.0.0",
-        "sc-broker": "~4.1.1",
-        "sc-channel": "~1.1.0",
-        "sc-errors": "~1.3.3",
-        "sc-hasher": "~1.0.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.0.0.tgz",
-          "integrity": "sha1-0JAK04WvE4BFQKEJxCFm4657K50=",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.8.0"
-          }
-        },
-        "sc-channel": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/sc-channel/-/sc-channel-1.1.0.tgz",
-          "integrity": "sha512-zuIiFWr45oKcjqmyzUuodMPSiS9lYsgiuuvC0EOkqLZffw0aZMGj5FsD4OSbzV/BeTJYPwzEq0P/IJd/2pqcnw==",
-          "dev": true,
-          "requires": {
-            "component-emitter": "1.2.1"
-          }
-        }
-      }
-    },
     "sc-channel": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/sc-channel/-/sc-channel-1.0.6.tgz",
@@ -12121,80 +11919,6 @@
       "resolved": "https://registry.npmjs.org/sc-formatter/-/sc-formatter-3.0.2.tgz",
       "integrity": "sha512-9PbqYBpCq+OoEeRQ3QfFIGE6qwjjBcd2j7UjgDlhnZbtSnuGgHdcRklPKYGuYFH82V/dwd+AIpu8XvA1zqTd+A==",
       "dev": true
-    },
-    "sc-hasher": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/sc-hasher/-/sc-hasher-1.0.0.tgz",
-      "integrity": "sha1-uyKuH1opW4R8cK/0UVU2IklQ/xE=",
-      "dev": true
-    },
-    "sc-jsonwebtoken": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/sc-jsonwebtoken/-/sc-jsonwebtoken-7.4.2.tgz",
-      "integrity": "sha1-Kp9n2JHlroNCIQhSC4NoroM2x0k=",
-      "dev": true,
-      "requires": {
-        "joi": "^6.10.1",
-        "jws": "^3.1.4",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.0.0",
-        "xtend": "^4.0.1"
-      },
-      "dependencies": {
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
-        },
-        "isemail": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
-          "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo=",
-          "dev": true
-        },
-        "joi": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
-          "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.x.x",
-            "isemail": "1.x.x",
-            "moment": "2.x.x",
-            "topo": "1.x.x"
-          }
-        },
-        "topo": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
-          "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.x.x"
-          }
-        }
-      }
-    },
-    "sc-simple-broker": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/sc-simple-broker/-/sc-simple-broker-2.1.2.tgz",
-      "integrity": "sha512-8hbr47jLhrMecShZi6lunEeUPySkuLHlpg6G7g5jbBJQRrBiFiTuQdwk7KpMwAjLBh1qfaoku9Z+yWieOd5oLA==",
-      "dev": true,
-      "requires": {
-        "sc-channel": "~1.2.0"
-      },
-      "dependencies": {
-        "sc-channel": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/sc-channel/-/sc-channel-1.2.0.tgz",
-          "integrity": "sha512-M3gdq8PlKg0zWJSisWqAsMmTVxYRTpVRqw4CWAdKBgAfVKumFcTjoCV0hYu7lgUXccCtCD8Wk9VkkE+IXCxmZA==",
-          "dev": true,
-          "requires": {
-            "component-emitter": "1.2.1"
-          }
-        }
-      }
     },
     "semver": {
       "version": "5.5.0",
@@ -12582,158 +12306,6 @@
         "hoek": "4.x.x"
       }
     },
-    "socketcluster": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/socketcluster/-/socketcluster-6.8.0.tgz",
-      "integrity": "sha512-RcR0g0YxozkKzDZqtqGxVBjB6Vqkze4VRTXFimNh2CPh8iemquJtZsrRj2oaMyJYUlLQZbO5TrlIsHIK0kSwQQ==",
-      "dev": true,
-      "requires": {
-        "async": "2.0.0",
-        "base64id": "0.1.0",
-        "fs-extra": "2.0.0",
-        "inquirer": "1.1.3",
-        "minimist": "1.1.0",
-        "sc-auth": "~4.1.1",
-        "sc-broker-cluster": "~4.3.0",
-        "sc-errors": "~1.3.3",
-        "socketcluster-server": "~6.3.0",
-        "uid-number": "0.0.5",
-        "uuid": "3.1.0"
-      },
-      "dependencies": {
-        "ansi-escapes": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
-          "dev": true
-        },
-        "async": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.0.0.tgz",
-          "integrity": "sha1-0JAK04WvE4BFQKEJxCFm4657K50=",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.8.0"
-          }
-        },
-        "cli-cursor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "^1.0.1"
-          }
-        },
-        "external-editor": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
-          "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
-          "dev": true,
-          "requires": {
-            "extend": "^3.0.0",
-            "spawn-sync": "^1.0.15",
-            "tmp": "^0.0.29"
-          }
-        },
-        "figures": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "^1.0.5",
-            "object-assign": "^4.1.0"
-          }
-        },
-        "fs-extra": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.0.0.tgz",
-          "integrity": "sha1-M3NSve1KC3FPPrhN6M6nZenTdgA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0"
-          }
-        },
-        "inquirer": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.1.3.tgz",
-          "integrity": "sha1-bNKpP3CfpQd5cx/SJixpgVXKsvo=",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "^1.1.0",
-            "chalk": "^1.0.0",
-            "cli-cursor": "^1.0.1",
-            "cli-width": "^2.0.0",
-            "external-editor": "^1.0.1",
-            "figures": "^1.3.5",
-            "lodash": "^4.3.0",
-            "mute-stream": "0.0.6",
-            "pinkie-promise": "^2.0.0",
-            "run-async": "^2.2.0",
-            "rx": "^4.1.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.0",
-            "through": "^2.3.6"
-          }
-        },
-        "minimist": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz",
-          "integrity": "sha1-zfIl6ImPhAolje1E/JF3Z3Cv3JM=",
-          "dev": true
-        },
-        "mute-stream": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
-          "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s=",
-          "dev": true
-        },
-        "onetime": {
-          "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-          "dev": true
-        },
-        "restore-cursor": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-          "dev": true,
-          "requires": {
-            "exit-hook": "^1.0.0",
-            "onetime": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "tmp": {
-          "version": "0.0.29",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
-          "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "~1.0.1"
-          }
-        },
-        "uuid": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
-          "dev": true
-        }
-      }
-    },
     "socketcluster-client": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/socketcluster-client/-/socketcluster-client-5.5.2.tgz",
@@ -12770,58 +12342,6 @@
           "dev": true,
           "requires": {
             "safe-buffer": "~5.0.1",
-            "ultron": "~1.1.0"
-          }
-        }
-      }
-    },
-    "socketcluster-server": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/socketcluster-server/-/socketcluster-server-6.3.0.tgz",
-      "integrity": "sha512-2QJgO/pexSY6Tkc3t9CqbD0gNYqV0RopYWeWMjCgmMU7ulMmAzJh5Vn08WRGP7J+ukjO1F16TfmKfVsiT63yuw==",
-      "dev": true,
-      "requires": {
-        "async": "2.0.0",
-        "base64id": "0.1.0",
-        "component-emitter": "1.2.1",
-        "lodash.clonedeep": "4.5.0",
-        "sc-auth": "~4.1.1",
-        "sc-errors": "~1.3.3",
-        "sc-formatter": "~3.0.0",
-        "sc-simple-broker": "~2.1.0",
-        "uuid": "3.1.0",
-        "uws": "8.14.0",
-        "ws": "3.1.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.0.0.tgz",
-          "integrity": "sha1-0JAK04WvE4BFQKEJxCFm4657K50=",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.8.0"
-          }
-        },
-        "ultron": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-          "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
-          "dev": true
-        },
-        "ws": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-3.1.0.tgz",
-          "integrity": "sha512-TU4/qKFlyQFqNITNWiqPCUY9GqlAhEotlzfcZcve6VT1YEngQl1dDMqwQQS3eMYruJ5r/UD3lcsWib6iVMDGDw==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0",
             "ultron": "~1.1.0"
           }
         }
@@ -12876,16 +12396,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
-    },
-    "spawn-sync": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
-      "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
-      "dev": true,
-      "requires": {
-        "concat-stream": "^1.4.7",
-        "os-shim": "^0.1.2"
-      }
     },
     "spdx-correct": {
       "version": "3.0.0",
@@ -14152,12 +13662,6 @@
       "dev": true,
       "optional": true
     },
-    "uid-number": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
-      "integrity": "sha1-Wj2yPvXb1VuB/ODsmirG/M3ruB4=",
-      "dev": true
-    },
     "ultron": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
@@ -14425,12 +13929,6 @@
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/uuid-js/-/uuid-js-0.7.5.tgz",
       "integrity": "sha1-bIhtAqU9LUDc8l2RoXC0p7JblNA="
-    },
-    "uws": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/uws/-/uws-8.14.0.tgz",
-      "integrity": "sha1-rMFIjRPssj/i+UKn6vsGaB+pFDE=",
-      "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "react-test-renderer": "^16.3.1",
     "redux-devtools": "^3.4.1",
     "remote-redux-devtools": "^0.5.12",
-    "remotedev-rn-debugger": "^0.8.3",
     "ts-jest": "^22.4.2",
     "tslint": "^5.9.1",
     "tslint-immutable": "^4.5.3",

--- a/src/application/store.ts
+++ b/src/application/store.ts
@@ -16,10 +16,7 @@ const router = buildRouter();
 const saga = buildSaga();
 const middleware = applyMiddleware(router.middleware, saga.middleware);
 
-const composeEnhancers = composeWithDevTools({
-    hostname: 'localhost', port: 5678,
-    name: Platform.OS,
-});
+const composeEnhancers = composeWithDevTools;
 const enhancers = composeEnhancers(router.enhancer, middleware);
 const reducer = combineReducers({ location: router.reducer, applicationState: reducerForApplicationState });
 

--- a/src/application/store.ts
+++ b/src/application/store.ts
@@ -1,4 +1,6 @@
-import { createStore, compose, applyMiddleware, combineReducers } from 'redux';
+import { Platform } from 'react-native';
+import { createStore, applyMiddleware, combineReducers } from 'redux';
+import { composeWithDevTools } from 'remote-redux-devtools';
 
 import { reducer as reducerForApplicationState, Store as StoreForApplicationState } from '../stores';
 import { buildSaga, runSaga } from '../sagas';
@@ -12,10 +14,16 @@ export type Store = {
 
 const router = buildRouter();
 const saga = buildSaga();
-
-const reducer = combineReducers({ location: router.reducer, applicationState: reducerForApplicationState });
 const middleware = applyMiddleware(router.middleware, saga.middleware);
-export const store = createStore(reducer, compose(router.enhancer, middleware));
+
+const composeEnhancers = composeWithDevTools({
+    hostname: 'localhost', port: 5678,
+    name: Platform.OS,
+});
+const enhancers = composeEnhancers(router.enhancer, middleware);
+const reducer = combineReducers({ location: router.reducer, applicationState: reducerForApplicationState });
+
+export const store = createStore(reducer, enhancers);
 
 runSaga(saga.middleware); // tslint:disable-line:no-expression-statement
 store.dispatch(loadCurrentLocaleActions.request()); // tslint:disable-line:no-expression-statement

--- a/src/application/store.ts
+++ b/src/application/store.ts
@@ -1,6 +1,5 @@
-import { Platform } from 'react-native';
 import { createStore, applyMiddleware, combineReducers } from 'redux';
-import { composeWithDevTools } from 'remote-redux-devtools';
+import { composeWithDevTools as compose } from 'remote-redux-devtools';
 
 import { reducer as reducerForApplicationState, Store as StoreForApplicationState } from '../stores';
 import { buildSaga, runSaga } from '../sagas';
@@ -16,8 +15,7 @@ const router = buildRouter();
 const saga = buildSaga();
 const middleware = applyMiddleware(router.middleware, saga.middleware);
 
-const composeEnhancers = composeWithDevTools;
-const enhancers = composeEnhancers(router.enhancer, middleware);
+const enhancers = compose(router.enhancer, middleware);
 const reducer = combineReducers({ location: router.reducer, applicationState: reducerForApplicationState });
 
 export const store = createStore(reducer, enhancers);

--- a/yarn.lock
+++ b/yarn.lock
@@ -858,10 +858,6 @@ ansi-cyan@^0.1.1:
   dependencies:
     ansi-wrap "0.1.0"
 
-ansi-escapes@^1.1.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
-
 ansi-escapes@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
@@ -1067,12 +1063,6 @@ async-each@^1.0.0:
 async-limiter@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
-
-async@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.0.0.tgz#d0900ad385af13804540a109c42166e3ae7b2b9d"
-  dependencies:
-    lodash "^4.8.0"
 
 async@^0.9.0:
   version "0.9.2"
@@ -1854,10 +1844,6 @@ base64-js@^1.1.2, base64-js@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
 
-base64id@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/base64id/-/base64id-0.1.0.tgz#02ce0fdeee0cef4f40080e1e73e834f0b1bfce3f"
-
 base64url@2.0.0, base64url@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/base64url/-/base64url-2.0.0.tgz#eac16e03ea1438eff9423d69baa36262ed1f70bb"
@@ -1916,21 +1902,6 @@ body-parser@1.18.2, body-parser@^1.15.2:
     qs "6.5.1"
     raw-body "2.3.2"
     type-is "~1.6.15"
-
-body-parser@^1.15.0:
-  version "1.18.3"
-  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.3.tgz#5b292198ffdd553b3a0f20ded0592b956955c8b4"
-  dependencies:
-    bytes "3.0.0"
-    content-type "~1.0.4"
-    debug "2.6.9"
-    depd "~1.1.2"
-    http-errors "~1.6.3"
-    iconv-lite "0.4.23"
-    on-finished "~2.3.0"
-    qs "6.5.2"
-    raw-body "2.3.3"
-    type-is "~1.6.16"
 
 boolbase@~1.0.0:
   version "1.0.0"
@@ -2128,7 +2099,7 @@ chalk@1.1.1:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
+chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -2365,7 +2336,7 @@ component-emitter@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.0.tgz#ccd113a86388d06482d03de3fc7df98526ba8efe"
 
-component-emitter@1.2.1, component-emitter@^1.2.0, component-emitter@^1.2.1:
+component-emitter@^1.2.0, component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
 
@@ -2482,13 +2453,6 @@ core-js@^2.2.2, core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0, core-js@^2.5.3:
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
-
-cors@^2.7.1:
-  version "2.8.4"
-  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.4.tgz#2bd381f2eb201020105cd50ea59da63090694686"
-  dependencies:
-    object-assign "^4"
-    vary "^1"
 
 cpx@^1.5.0:
   version "1.5.0"
@@ -3055,10 +3019,6 @@ exists-async@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/exists-async/-/exists-async-2.0.0.tgz#7e0b1652b34b0fe18b9f9640987bd56d59e51e5e"
 
-exit-hook@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
-
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
@@ -3134,10 +3094,6 @@ expect@^22.4.3:
     jest-message-util "^22.4.3"
     jest-regex-util "^22.4.3"
 
-expirymanager@~0.9.3:
-  version "0.9.3"
-  resolved "https://registry.yarnpkg.com/expirymanager/-/expirymanager-0.9.3.tgz#e5f6b3ba00d8d76cf63311c2b71d7dfc9bde3e4f"
-
 expo@^27.0.0:
   version "27.0.1"
   resolved "https://registry.yarnpkg.com/expo/-/expo-27.0.1.tgz#556a37121282f4509b0821d8d4e7c8a8da0c11d8"
@@ -3161,7 +3117,7 @@ expo@^27.0.0:
     uuid-js "^0.7.5"
     websql "https://github.com/expo/node-websql/archive/18.0.0.tar.gz"
 
-express@^4.13.3, express@^4.13.4:
+express@^4.13.4:
   version "4.16.3"
   resolved "https://registry.yarnpkg.com/express/-/express-4.16.3.tgz#6af8a502350db3246ecc4becf6b5a34d22f7ed53"
   dependencies:
@@ -3218,14 +3174,6 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
 extend@3, extend@^3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
-
-external-editor@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-1.1.1.tgz#12d7b0db850f7ff7e7081baf4005700060c4600b"
-  dependencies:
-    extend "^3.0.0"
-    spawn-sync "^1.0.15"
-    tmp "^0.0.29"
 
 external-editor@^2.0.4, external-editor@^2.1.0:
   version "2.2.0"
@@ -3440,10 +3388,6 @@ find-up@^2.0.0, find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
-fleximap@~0.9.10:
-  version "0.9.10"
-  resolved "https://registry.yarnpkg.com/fleximap/-/fleximap-0.9.10.tgz#1aa50ff6a8fea0037cc378e38ddacc091025ac10"
-
 follow-redirects@^1.2.3:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.4.1.tgz#d8120f4518190f55aac65bb6fc7b85fcd666d6aa"
@@ -3497,13 +3441,6 @@ freeport-async@^1.1.1:
 fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
-
-fs-extra@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-2.0.0.tgz#337352bded4a0b714f3eb84de8cea765e9d37600"
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^2.1.0"
 
 fs-extra@6.0.0:
   version "6.0.0"
@@ -3617,6 +3554,10 @@ get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
 
+get-params@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/get-params/-/get-params-0.1.2.tgz#bae0dfaba588a0c60d7834c0d8dc2ff60eeef2fe"
+
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
@@ -3649,10 +3590,6 @@ getpass@^0.1.1:
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
   dependencies:
     assert-plus "^1.0.0"
-
-getport@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/getport/-/getport-0.1.0.tgz#abddf3d5d1e77dd967ccfa2b036a0a1fb26fd7f7"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -3925,7 +3862,7 @@ http-errors@1.6.2:
     setprototypeof "1.0.3"
     statuses ">= 1.3.1 < 2"
 
-http-errors@1.6.3, http-errors@~1.6.2, http-errors@~1.6.3:
+http-errors@1.6.3, http-errors@~1.6.2:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
   dependencies:
@@ -4033,25 +3970,6 @@ inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, i
 ini@^1.3.4, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
-
-inquirer@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-1.1.3.tgz#6cd2a93f709fa50779731fd2262c698155cab2fa"
-  dependencies:
-    ansi-escapes "^1.1.0"
-    chalk "^1.0.0"
-    cli-cursor "^1.0.1"
-    cli-width "^2.0.0"
-    external-editor "^1.0.1"
-    figures "^1.3.5"
-    lodash "^4.3.0"
-    mute-stream "0.0.6"
-    pinkie-promise "^2.0.0"
-    run-async "^2.2.0"
-    rx "^4.1.0"
-    string-width "^1.0.1"
-    strip-ansi "^3.0.0"
-    through "^2.3.6"
 
 inquirer@^3.0.1, inquirer@^3.0.6:
   version "3.3.0"
@@ -4800,10 +4718,6 @@ join-component@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/join-component/-/join-component-1.1.0.tgz#b8417b750661a392bee2c2537c68b2a9d4977cd5"
 
-js-data@^2.9.0:
-  version "2.10.1"
-  resolved "https://registry.yarnpkg.com/js-data/-/js-data-2.10.1.tgz#6b109ea588255768b21864b7a954b39086e3701d"
-
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
@@ -5072,10 +4986,6 @@ lodash-es@^4.17.5, lodash-es@^4.2.1:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.10.tgz#62cd7104cdf5dd87f235a837f0ede0e8e5117e05"
 
-lodash.clonedeep@4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
-
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
@@ -5120,7 +5030,7 @@ lodash@^3.5.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.10.1, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.14.1, lodash@^4.15.0, lodash@^4.16.6, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1, lodash@^4.8.0:
+lodash@^4.0.0, lodash@^4.10.1, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.14.1, lodash@^4.15.0, lodash@^4.16.6, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -5602,10 +5512,6 @@ ms@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
 
-mute-stream@0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.6.tgz#48962b19e169fd1dfc240b3f1e7317627bbc47db"
-
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
@@ -5678,12 +5584,6 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
-ncom@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/ncom/-/ncom-1.0.1.tgz#1c5caf25c7821339d6df3788ec15654cf5ce1272"
-  dependencies:
-    sc-formatter "~3.0.1"
-
 ncp@^2.0.0, ncp@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
@@ -5755,10 +5655,6 @@ node-pre-gyp@^0.9.0:
     rimraf "^2.6.1"
     semver "^5.3.0"
     tar "^4"
-
-node-uuid@^1.4.0:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.8.tgz#b040eb0923968afabf8d32fb1f17f1167fdab907"
 
 nomnom@~1.6.2:
   version "1.6.2"
@@ -5857,7 +5753,7 @@ oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4, object-assign@^4.0.0, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -5954,10 +5850,6 @@ once@^1.3.0, once@^1.4.0:
   dependencies:
     wrappy "1"
 
-onetime@^1.0.0:
-  version "1.1.0"
-  resolved "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
-
 onetime@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
@@ -6027,11 +5919,7 @@ os-name@^2.0.1:
     macos-release "^1.0.0"
     win-release "^1.0.0"
 
-os-shim@^0.1.2:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/os-shim/-/os-shim-0.1.3.tgz#6b62c3791cf7909ea35ed46e17658bb417cb3917"
-
-os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
@@ -6445,7 +6333,7 @@ qs@6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
-qs@6.5.2, qs@^6.4.0, qs@^6.5.0, qs@^6.5.1, qs@~6.5.1:
+qs@^6.4.0, qs@^6.5.0, qs@^6.5.1, qs@~6.5.1:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
@@ -6509,7 +6397,7 @@ raw-body@2.3.2:
     iconv-lite "0.4.19"
     unpipe "1.0.0"
 
-raw-body@2.3.3, raw-body@^2.2.0:
+raw-body@^2.2.0:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.3.tgz#1b324ece6b5706e153855bc1148c65bb7f6ea0c3"
   dependencies:
@@ -6874,7 +6762,7 @@ redent@^1.0.0:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
 
-redux-devtools-instrument@^1.0.1:
+redux-devtools-instrument@^1.0.1, redux-devtools-instrument@^1.3.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/redux-devtools-instrument/-/redux-devtools-instrument-1.8.3.tgz#c510d67ab4e5e4525acd6e410c25ab46b85aca7c"
   dependencies:
@@ -7007,39 +6895,11 @@ remote-redux-devtools@^0.5.12:
     rn-host-detect "^1.0.1"
     socketcluster-client "^5.3.1"
 
-remotedev-rn-debugger@^0.8.3:
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/remotedev-rn-debugger/-/remotedev-rn-debugger-0.8.3.tgz#89f22ecb52d0bc56717c51fdc6dad98ff3541a45"
-  dependencies:
-    chalk "^2.0.1"
-    minimist "^1.2.0"
-    remotedev-server "^0.2.4"
-    semver "^5.4.1"
-
 remotedev-serialize@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/remotedev-serialize/-/remotedev-serialize-0.1.1.tgz#0f598000b7dd7515d67f9b51a61d211e18ce9554"
   dependencies:
     jsan "^3.1.9"
-
-remotedev-server@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/remotedev-server/-/remotedev-server-0.2.4.tgz#b019b015132064cd76024cb91eb026801f24cd67"
-  dependencies:
-    body-parser "^1.15.0"
-    chalk "^1.1.3"
-    cors "^2.7.1"
-    ejs "^2.4.1"
-    express "^4.13.3"
-    getport "^0.1.0"
-    js-data "^2.9.0"
-    lodash "^4.15.0"
-    minimist "^1.2.0"
-    node-uuid "^1.4.0"
-    object-assign "^4.0.0"
-    repeat-string "^1.5.4"
-    semver "^5.3.0"
-    socketcluster "^6.7.1"
 
 remotedev-utils@^0.1.1:
   version "0.1.4"
@@ -7063,7 +6923,7 @@ repeat-element@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
 
-repeat-string@^1.5.2, repeat-string@^1.5.4, repeat-string@^1.6.1:
+repeat-string@^1.5.2, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
@@ -7196,13 +7056,6 @@ rest-facade@^1.10.0:
     superagent "^3.8.0"
     superagent-proxy "^1.0.2"
 
-restore-cursor@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
-  dependencies:
-    exit-hook "^1.0.0"
-    onetime "^1.0.0"
-
 restore-cursor@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
@@ -7277,10 +7130,6 @@ rx-lite@*, rx-lite@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
-rx@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
-
 rxjs@^5.5.2:
   version "5.5.10"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.10.tgz#fde02d7a614f6c8683d0d1957827f492e09db045"
@@ -7335,6 +7184,26 @@ sax@^1.2.4:
 sax@~1.1.1:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.1.6.tgz#5d616be8a5e607d54e114afae55b7eaf2fcc3240"
+
+sc-channel@~1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/sc-channel/-/sc-channel-1.0.6.tgz#b38bd47a993e78290fbc53467867f6b2a0a08639"
+  dependencies:
+    sc-emitter "1.x.x"
+
+sc-emitter@1.x.x, sc-emitter@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/sc-emitter/-/sc-emitter-1.1.0.tgz#ef119d4222f4c64f887b486964ef11116cdd0e75"
+  dependencies:
+    component-emitter "1.2.0"
+
+sc-errors@~1.3.0:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/sc-errors/-/sc-errors-1.3.3.tgz#c00bc4c766a970cc8d5937d08cd58e931d7dae05"
+
+sc-formatter@~3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/sc-formatter/-/sc-formatter-3.0.2.tgz#9abdb14e71873ce7157714d3002477bbdb33c4e6"
 
 semver-diff@^2.0.0:
   version "2.1.0"
@@ -7547,38 +7416,6 @@ socketcluster-client@^5.3.1:
     sc-formatter "~3.0.0"
     ws "3.0.0"
 
-socketcluster-server@~6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/socketcluster-server/-/socketcluster-server-6.3.0.tgz#7a1fcc8933e53e1654048bc36b36fc3ae12aed6b"
-  dependencies:
-    async "2.0.0"
-    base64id "0.1.0"
-    component-emitter "1.2.1"
-    lodash.clonedeep "4.5.0"
-    sc-auth "~4.1.1"
-    sc-errors "~1.3.3"
-    sc-formatter "~3.0.0"
-    sc-simple-broker "~2.1.0"
-    uuid "3.1.0"
-    uws "8.14.0"
-    ws "3.1.0"
-
-socketcluster@^6.7.1:
-  version "6.8.0"
-  resolved "https://registry.yarnpkg.com/socketcluster/-/socketcluster-6.8.0.tgz#41cf838b0ba982eefdd8e8051967b76e39d7ee73"
-  dependencies:
-    async "2.0.0"
-    base64id "0.1.0"
-    fs-extra "2.0.0"
-    inquirer "1.1.3"
-    minimist "1.1.0"
-    sc-auth "~4.1.1"
-    sc-broker-cluster "~4.3.0"
-    sc-errors "~1.3.3"
-    socketcluster-server "~6.3.0"
-    uid-number "0.0.5"
-    uuid "3.1.0"
-
 socks-proxy-agent@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-3.0.1.tgz#2eae7cf8e2a82d34565761539a7f9718c5617659"
@@ -7633,13 +7470,6 @@ source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, sour
 source-map@^0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-
-spawn-sync@^1.0.15:
-  version "1.0.15"
-  resolved "https://registry.yarnpkg.com/spawn-sync/-/spawn-sync-1.0.15.tgz#b00799557eb7fb0c8376c29d44e8a1ea67e57476"
-  dependencies:
-    concat-stream "^1.4.7"
-    os-shim "^0.1.2"
 
 spdx-correct@^3.0.0:
   version "3.0.0"
@@ -7994,12 +7824,6 @@ title-case@^1.1.0:
     sentence-case "^1.1.1"
     upper-case "^1.0.3"
 
-tmp@^0.0.29:
-  version "0.0.29"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.29.tgz#f25125ff0dd9da3ccb0c2dd371ee1288bb9128c0"
-  dependencies:
-    os-tmpdir "~1.0.1"
-
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -8181,10 +8005,6 @@ uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
 
-uid-number@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.5.tgz#5a3db23ef5dbd55b81fce0ec9a2ac6fccdebb81e"
-
 ultron@1.0.x:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
@@ -8314,10 +8134,6 @@ uuid@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
 
-uuid@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
-
 uuid@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
@@ -8325,10 +8141,6 @@ uuid@^2.0.1:
 uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0, uuid@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
-
-uws@8.14.0:
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/uws/-/uws-8.14.0.tgz#acc1488d13ecb23fe2f942a7eafb06681fa91431"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.3"
@@ -8341,7 +8153,7 @@ value-equal@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"
 
-vary@^1, vary@~1.1.2:
+vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
 
@@ -8489,7 +8301,7 @@ write-file-atomic@^1.2.0:
     imurmurhash "^0.1.4"
     slide "^1.1.5"
 
-write-file-atomic@^2.1.0, write-file-atomic@^2.3.0:
+write-file-atomic@^2.0.0, write-file-atomic@^2.1.0, write-file-atomic@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.3.0.tgz#1ff61575c2e2a4e8e510d6fa4e243cce183999ab"
   dependencies:
@@ -8504,13 +8316,6 @@ ws@3.0.0:
     safe-buffer "~5.0.1"
     ultron "~1.1.0"
 
-ws@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-3.1.0.tgz#8afafecdeab46d572e5397ee880739367aa2f41c"
-  dependencies:
-    safe-buffer "~5.1.0"
-    ultron "~1.1.0"
-
 ws@^1.1.0:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.5.tgz#cbd9e6e75e09fc5d2c90015f21f0c40875e0dd51"
@@ -8523,14 +8328,6 @@ ws@^2.0.3:
   resolved "https://registry.yarnpkg.com/ws/-/ws-2.3.1.tgz#6b94b3e447cb6a363f785eaf94af6359e8e81c80"
   dependencies:
     safe-buffer "~5.0.1"
-    ultron "~1.1.0"
-
-ws@^3.3.1:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
-  dependencies:
-    async-limiter "~1.0.0"
-    safe-buffer "~5.1.0"
     ultron "~1.1.0"
 
 ws@^4.0.0:


### PR DESCRIPTION
Updated:
- Gives Remote Redux DevTools access to our Redux store state when running in debugging mode.
- Removes `remotedev-rn-debugger` as it was causing build step to hang and doesn't work consistently anyway.

There are via two methods to access Redux DevTools remotely:
- Visit http://remotedev.io/local/ : (should "just work" on iOS and Android simulators via https/port 443).
- The Redux DevTools Chrome Extension (only works with iOS simulator, likely because of port forwarding issues on Android's Simulator):
  1. Enable remote debugging in Expo.
  2. Open Chrome's dev inspector (on macOS: option+cmd+i).
  3. Open the Redux tab press.
  4. Start a remote session (ctrl+cmd+downarrow on macOS).

~Add devserver config back to store creation (lost in a rebase conflict resolution).~

~I just noticed that redux devtools only works for me on iOS; I get socket connection errors in the console on Android. Seems like a common problem: https://github.com/zalmoxisus/remote-redux-devtools/search?q=socket+hung+up+android&type=Issues but the recommended fixes did not work for me.~