### PR TITLE
Issue #90 Fix jest regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "transformIgnorePatterns": [
       "node_modules/(?!(react-native|expo|@expo/.*|native-base)/)"
     ],
-    "testRegex": "/__tests__/[\\w]+\\.(test|spec)\\.tsx?$",
+    "testRegex": "/__tests__/.+\\.(test|spec)\\.tsx?$",
     "moduleFileExtensions": [
       "ts",
       "tsx",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "transformIgnorePatterns": [
       "node_modules/(?!(react-native|expo|@expo/.*|native-base)/)"
     ],
-    "testRegex": "/__tests__/.+\\.(test|spec)\\.tsx?$",
+    "testRegex": "/__tests__/[-a-zA-Z0-9_]+\\.(test|spec)\\.tsx?$",
     "moduleFileExtensions": [
       "ts",
       "tsx",


### PR DESCRIPTION
After some playing around, it seems to me that it doesn't understand the `\w` character set. When I replace that with a `.` then it manages to find and run all the tests. However, there is still a locale error that I don't understand. Here is the output:
```
$ yarn test
yarn run v1.7.0
$ yarn run build && yarn run jest
$ tsc
$ C:\Users\Theresa\PeaceGeeks\pathways-frontend\node_modules\.bin\jest
 PASS  src\sagas\__tests__\fonts.test.ts (5.803s)
 PASS  src\sagas\__tests__\locale.test.ts
  ● Console

    console.error src\sagas\locale.ts:42
      Failed to load current locale (43e96a8d-9bf8-4318-ae3b-7b4df3743940)

 PASS  src\stores\__tests__\questionnaire.test.ts
 PASS  src\stores\__tests__\tasks.test.ts
 PASS  src\stores\__tests__\tasks_helpers.test.ts
 PASS  src\selectors\__tests__\tasks.test.ts
 PASS  src\stores\__tests__\page_switcher.test.ts
 PASS  src\stores\__tests__\locale.test.ts
 PASS  src\selectors\__tests__\questionnaire.test.ts
 PASS  src\application\locale\__tests__\locale.test.ts
 PASS  src\stores\__tests__\questionnaire_helpers.test.ts
 PASS  src\stores\__tests__\fonts.test.ts

Test Suites: 12 passed, 12 total
Tests:       113 passed, 113 total
Snapshots:   0 total
Time:        11.243s, estimated 25s
Ran all test suites.
Done in 21.94s.
```

@tnightingale I can see that you were changing things with the `jest` command. Was it working for you with the `\w`?