### PR TITLE
Issue #95 Seperate "set locale" and "load current locale" sagas

### DIFF
--- a/src/application/locale/__tests__/locale.test.ts
+++ b/src/application/locale/__tests__/locale.test.ts
@@ -11,6 +11,10 @@ describe('LocaleManager', () => {
             expect(() => LocaleManager.get(aString())).toThrow();
         });
 
+        it('.getFallbackLocale() should throw an error', () => {
+            expect(() => LocaleManager.getFallbackLocale()).toThrow();
+        });
+
         it('.locales should throw an error', () => {
             expect(() => LocaleManager.locales).toThrow();
         });
@@ -54,6 +58,10 @@ describe('LocaleManager', () => {
 
         it('.get() should throw an error if given an unknown locale code', () => {
             expect(() => LocaleManager.get(aString())).toThrow();
+        });
+
+        it('.getFallbackLocale() should return the first registered locale', () => {
+            expect(LocaleManager.getFallbackLocale()).toBe(aLocale);
         });
 
         it('.locales should be an array of the known locales', () => {

--- a/src/application/locale/index.ts
+++ b/src/application/locale/index.ts
@@ -57,6 +57,10 @@ export class LocaleManager {
         return this.instance.locale(code);
     }
 
+    static getFallbackLocale(): Locale {
+        return this.instance.getFallbackLocale();
+    }
+
     static get locales(): ReadonlyArray<Locale> {
         return this.instance.locales;
     }
@@ -80,6 +84,8 @@ export class LocaleManager {
         return this.localeManagerInstance;
     }
 
+    private fallbackLocaleCode: string;
+
     private locales: ReadonlyArray<Locale>;
 
     private catalogsMap: CatalogsMap;
@@ -95,6 +101,15 @@ export class LocaleManager {
             throw new Error(`Unknown locale code: ${code}`);
         }
         return locale;
+    }
+
+    private getFallbackLocale(): Locale {
+        if (this.fallbackLocaleCode) {
+            return this.locale(this.fallbackLocaleCode);
+        } else {
+            const [ fallbackLocale ]: ReadonlyArray<Locale> = this.locales;
+            return fallbackLocale;
+        }
     }
 
 }

--- a/src/sagas/__tests__/locale.test.ts
+++ b/src/sagas/__tests__/locale.test.ts
@@ -1,10 +1,10 @@
-// tslint:disable:no-expression-statement
-import { call, put } from 'redux-saga/effects';
+// tslint:disable:no-expression-statement no-let no-null-keyword
+import { call, put, PutEffect, CallEffect } from 'redux-saga/effects';
 
 import { buildLocale } from '../../stores/__tests__/helpers/locale_helpers';
 import { loadCurrentLocaleCode, saveCurrentLocaleCode, isReloadNeeded, reloadRTL, LocaleManager } from '../../application/locale';
-import { loadCurrentLocaleActions, setLocaleActions } from '../../stores/locale';
-import { applyLocaleChange, loadCurrentLocale } from '../locale';
+import { loadCurrentLocaleActions, setLocaleActions, SetLocale } from '../../stores/locale';
+import { applyLocaleChange, loadCurrentLocale, LoadCurrentLocaleActions } from '../locale';
 import { anError } from '../../application/__tests__/helpers/random_test_values';
 
 describe('the loadCurrentLocale saga', () => {
@@ -15,25 +15,37 @@ describe('the loadCurrentLocale saga', () => {
         LocaleManager.registerLocale(aLocale);
     });
 
-    it('should dispatch a call effect with loadCurrentLocaleCode', () => {
+    it('should dispatch a call effect for loadCurrentLocaleCode()', () => {
         const saga = loadCurrentLocale();
         const value = saga.next().value;
-        const expected = call(loadCurrentLocaleCode);
-        expect(value).toEqual(expected);
+        expect(value).toEqual(call(loadCurrentLocaleCode));
     });
 
-    it('should dispatch a put effect with a success action upon completion of call effect', () => {
-        const saga = loadCurrentLocale();
-        expect(saga.next().value).toEqual(call(loadCurrentLocaleCode));
-        expect(saga.next(aLocale.code).value).toEqual(put(loadCurrentLocaleActions.success(aLocale)));
-    });
+    describe('after requesting the current locale code should', () => {
 
-    it('should dispatch a failure action upon failure of call effect', () => {
-        const error = anError();
-        const saga = loadCurrentLocale();
-        expect(saga.next().value).toEqual(call(loadCurrentLocaleCode));
-        expect(saga.throw(error).value)
-            .toEqual(put(loadCurrentLocaleActions.failure(error.message)));
+        let saga: IterableIterator<CallEffect | PutEffect<LoadCurrentLocaleActions>>;
+
+        beforeEach(() => {
+            saga = loadCurrentLocale();
+            saga.next();
+        });
+
+        it('dispatch a success action with the received locale code', () => {
+            const value = saga.next(aLocale.code).value;
+            expect(value).toEqual(put(loadCurrentLocaleActions.success(aLocale)));
+        });
+
+        it('dispatch a success action with the fallback locale code if no current locale is set', () => {
+            const value = saga.next(null).value;
+            expect(value).toEqual(put(loadCurrentLocaleActions.success(aLocale)));
+        });
+
+        it('dispatch a failure action upon failure to load a locale code', () => {
+            const error = anError();
+            const value = saga.throw(error).value;
+            expect(value).toEqual(put(loadCurrentLocaleActions.failure(error.message)));
+        });
+
     });
 
 });

--- a/src/sagas/__tests__/locale.test.ts
+++ b/src/sagas/__tests__/locale.test.ts
@@ -60,20 +60,27 @@ describe('the applyLocaleChange saga', () => {
         expect(saga.next().value).toEqual(call(saveCurrentLocaleCode, aLocale.code));
     });
 
-    it('should dispatch a put effect with a success action upon completion of call effect', () => {
-        const saga = applyLocaleChange(setLocaleAction);
-        expect(saga.next().value).toEqual(call(saveCurrentLocaleCode, aLocale.code));
-        expect(saga.next().value).toEqual(put(setLocaleActions.success(aLocale)));
-        expect(saga.next().value).toEqual(call(isReloadNeeded, aLocale));
-        expect(saga.next(true).value).toEqual(call(reloadRTL, aLocale.isRTL));
-    });
+    describe('after requesting the current locale be saved', () => {
 
-    it('should dispatch a failure action upon failure of call effect', () => {
-        const error = anError();
-        const saga = applyLocaleChange(setLocaleAction);
-        expect(saga.next().value).toEqual(call(saveCurrentLocaleCode, aLocale.code));
-        expect(saga.throw(error).value)
-            .toEqual(put(setLocaleActions.failure(error.message, aLocale)));
+        let saga: IterableIterator<CallEffect | PutEffect<SetLocale.Result>>;
+
+        beforeEach(() => {
+            saga = applyLocaleChange(setLocaleAction);
+            saga.next();
+        });
+
+        it('should dispatch a put effect with a success action upon completion of call effect', () => {
+            expect(saga.next().value).toEqual(put(setLocaleActions.success(aLocale)));
+            expect(saga.next().value).toEqual(call(isReloadNeeded, aLocale));
+            expect(saga.next(true).value).toEqual(call(reloadRTL, aLocale.isRTL));
+        });
+
+        it('should dispatch a failure action upon failure of call effect', () => {
+            const error = anError();
+            const value = saga.throw(error).value;
+            expect(value).toEqual(put(setLocaleActions.failure(error.message, aLocale)));
+        });
+
     });
 
 });

--- a/src/sagas/locale.ts
+++ b/src/sagas/locale.ts
@@ -26,17 +26,13 @@ export function* watchLoadLocale(): IterableIterator<ForkEffect> {
     yield takeLatest(constants.LOAD_CURRENT_LOCALE_REQUEST, loadCurrentLocale);
 }
 
-type LoadCurrentLocaleActions = LoadCurrentLocale.Request | LoadCurrentLocale.Result | SetLocale.Success;
+export type LoadCurrentLocaleActions = LoadCurrentLocale.Request | LoadCurrentLocale.Result | SetLocale.Success;
 
 export function* loadCurrentLocale(): IterableIterator<CallEffect | PutEffect<LoadCurrentLocaleActions>> {
     try {
-        const currentLocaleCode = yield call(loadCurrentLocaleCode);
-        if (currentLocaleCode !== null) {
-            const currentLocale = LocaleManager.get(currentLocaleCode);
-            yield put(loadCurrentLocaleActions.success(currentLocale));
-        } else {
-            yield put(loadCurrentLocaleActions.failure('No locale preference set'));
-        }
+        const code = yield call(loadCurrentLocaleCode);
+        const locale = code !== null ? LocaleManager.get(code) : LocaleManager.getFallbackLocale();
+        yield put(loadCurrentLocaleActions.success(locale));
     } catch (e) {
         console.error(`Failed to load current locale (${e.message})`);
         yield put(loadCurrentLocaleActions.failure(e.message));

--- a/src/sagas/locale.ts
+++ b/src/sagas/locale.ts
@@ -34,7 +34,6 @@ export function* loadCurrentLocale(): IterableIterator<CallEffect | PutEffect<Lo
         if (currentLocaleCode !== null) {
             const currentLocale = LocaleManager.get(currentLocaleCode);
             yield put(loadCurrentLocaleActions.success(currentLocale));
-            yield put(setLocaleActions.success(currentLocale));
         } else {
             yield put(loadCurrentLocaleActions.failure('No locale preference set'));
         }

--- a/src/stores/__tests__/locale.test.ts
+++ b/src/stores/__tests__/locale.test.ts
@@ -2,6 +2,7 @@
 import { Locale } from '../../application/locale';
 import * as locale from '../locale';
 import * as constants from '../../application/constants';
+import { aString } from '../../application/__tests__/helpers/random_test_values';
 import * as helpers from './helpers/locale_helpers';
 
 const aLocale = helpers.buildLocale().get();
@@ -108,6 +109,12 @@ describe('the loadCurrentLocaleAction for', () => {
 
 describe('the reducer', () => {
 
+    it('should return store unchanged if action is undefined', () => {
+        const theOriginalStore = buildStoreWithLocale(aLocale);
+        const theNewStore = locale.reducer(theOriginalStore, undefined);
+        expect(theNewStore).toBe(theOriginalStore);
+    });
+
     it('should default to build a store with default locale code `en`', () => {
         const theStore = locale.reducer();
         expect(theStore.code).toBe('en');
@@ -135,7 +142,7 @@ describe('the reducer', () => {
     });
 
     it('when called with SET_LOCALE_FAILURE should return store with loading flag set false', () => {
-        const errorMessage = '[test] Error occurred during setLocale';
+        const errorMessage = aString();
         const theStore = buildStoreLoadingLocale();
         const theAction = {
             type: constants.SET_LOCALE_FAILURE as typeof constants.SET_LOCALE_FAILURE,
@@ -154,10 +161,26 @@ describe('the reducer', () => {
         expect(theNewStore.loading).toBe(true);
     });
 
-    it('should return store unchanged if action is undefined', () => {
-        const theOriginalStore = buildStoreWithLocale(aLocale);
-        const theNewStore = locale.reducer(theOriginalStore, undefined);
-        expect(theNewStore.code).toBe(theOriginalStore.code);
+    it('when called with LOAD_CURRENTLOCALE_SUCCESS should return store with locale code from action', () => {
+        const theStore = buildStoreLoadingLocale();
+        const theAction = {
+            type: constants.LOAD_CURRENT_LOCALE_SUCCESS as typeof constants.LOAD_CURRENT_LOCALE_SUCCESS,
+            payload: { locale: aLocale },
+        };
+        const theNewStore = locale.reducer(theStore, theAction);
+        expect(theNewStore.code).toBe(theAction.payload.locale.code);
+        expect(theNewStore.loading).toBe(false);
+    });
+
+    it('when called with LOAD_CURERNT_LOCALE_FAILURE should return store with loading flag set false', () => {
+        const errorMessage = aString();
+        const theStore = buildStoreLoadingLocale();
+        const theAction = {
+            type: constants.LOAD_CURRENT_LOCALE_FAILURE as typeof constants.LOAD_CURRENT_LOCALE_FAILURE,
+            payload: { message: errorMessage, locale: aLocale },
+        };
+        const theNewStore = locale.reducer(theStore, theAction);
+        expect(theNewStore.loading).toBe(false);
     });
 
 });

--- a/src/stores/__tests__/locale.test.ts
+++ b/src/stores/__tests__/locale.test.ts
@@ -8,11 +8,11 @@ import * as helpers from './helpers/locale_helpers';
 const aLocale = helpers.buildLocale().get();
 
 const buildStoreWithLocale = (theLocale: Locale): locale.Store => {
-    return { code: theLocale.code, loading: false };
+    return { code: theLocale.code, errorMessage: '', loading: false };
 };
 
 const buildStoreLoadingLocale = (): locale.Store => {
-    return { code: aLocale.code, loading: true };
+    return { code: aLocale.code, errorMessage: '', loading: true };
 };
 
 describe('the setLocaleAction for', () => {

--- a/src/stores/locale/index.ts
+++ b/src/stores/locale/index.ts
@@ -7,7 +7,7 @@ import { LoadCurrentLocale } from './load_current_locale';
 export { SetLocale };
 export { LoadCurrentLocale };
 
-type ReducerActions = SetLocale.Request | SetLocale.Result | LoadCurrentLocale.Request;
+type ReducerActions = SetLocale.Request | SetLocale.Result | LoadCurrentLocale.Request | LoadCurrentLocale.Result;
 export type Store = Readonly<ReturnType<typeof buildDefaultStore>>;
 
 const DEFAULT_LOCALE_CODE = 'en';
@@ -25,14 +25,21 @@ export const reducer = (store: Store = buildDefaultStore(), action?: ReducerActi
         return store;
     }
     switch (action.type) {
+
         case constants.LOAD_CURRENT_LOCALE_REQUEST:
             return { ...store, loading: true };
+        case constants.LOAD_CURRENT_LOCALE_SUCCESS:
+            return { ...store, code: action.payload.locale.code, loading: false };
+        case constants.LOAD_CURRENT_LOCALE_FAILURE:
+            return { ...store, loading: false };
+
         case constants.SET_LOCALE_REQUEST:
             return { ...store, loading: true };
         case constants.SET_LOCALE_SUCCESS:
             return { ...store, code: action.payload.locale.code, loading: false };
         case constants.SET_LOCALE_FAILURE:
             return { ...store, loading: false };
+
         default:
             return store;
     }

--- a/src/stores/locale/index.ts
+++ b/src/stores/locale/index.ts
@@ -15,6 +15,7 @@ const DEFAULT_LOCALE_CODE = 'en';
 export const buildDefaultStore = () => ({
     code: DEFAULT_LOCALE_CODE,
     loading: false,
+    errorMessage: '',
 });
 
 export const setLocaleActions = setLocale;
@@ -29,16 +30,20 @@ export const reducer = (store: Store = buildDefaultStore(), action?: ReducerActi
         case constants.LOAD_CURRENT_LOCALE_REQUEST:
             return { ...store, loading: true };
         case constants.LOAD_CURRENT_LOCALE_SUCCESS:
-            return { ...store, code: action.payload.locale.code, loading: false };
-        case constants.LOAD_CURRENT_LOCALE_FAILURE:
-            return { ...store, loading: false };
+            return { ...buildDefaultStore(), code: action.payload.locale.code };
+        case constants.LOAD_CURRENT_LOCALE_FAILURE: {
+            const payload = action.payload;
+            return { ...buildDefaultStore(), errorMessage: payload.message };
+        }
 
         case constants.SET_LOCALE_REQUEST:
             return { ...store, loading: true };
         case constants.SET_LOCALE_SUCCESS:
-            return { ...store, code: action.payload.locale.code, loading: false };
-        case constants.SET_LOCALE_FAILURE:
-            return { ...store, loading: false };
+            return { ...buildDefaultStore(), code: action.payload.locale.code };
+        case constants.SET_LOCALE_FAILURE: {
+            const payload = action.payload;
+            return { ...buildDefaultStore(), errorMessage: payload.message };
+        }
 
         default:
             return store;


### PR DESCRIPTION
This tidies up the locale sagas implementation and fixes an issue on master where we get stuck on the loading screen (because the reducer currently handles the wrong action on initial startup (before a users locale preference has been persisted to database).