### PR TITLE
Update jsLingui to latest release (#99)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -577,15 +577,6 @@
         }
       }
     },
-    "@babel/runtime": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.46.tgz",
-      "integrity": "sha512-/3a3USMKk54BEHhDgY8rtxtaQOs4bp4aQwo6SDtdwmrXmgSgEusWuXNX5oIs/nwzmTD9o8wz2EyAjA+uHDMmJA==",
-      "requires": {
-        "core-js": "^2.5.3",
-        "regenerator-runtime": "^0.11.1"
-      }
-    },
     "@babel/template": {
       "version": "7.0.0-beta.46",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.46.tgz",
@@ -866,51 +857,52 @@
       }
     },
     "@lingui/babel-plugin-extract-messages": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@lingui/babel-plugin-extract-messages/-/babel-plugin-extract-messages-2.0.1.tgz",
-      "integrity": "sha512-XYvWVYHNVH/Gy3BRUb9yH1rcyYWkrBncqrUOHR4hC1FnabPjgwku9e9N4WiqGduKNlC1MxTNQBjwH653ZsX6XA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@lingui/babel-plugin-extract-messages/-/babel-plugin-extract-messages-2.1.0.tgz",
+      "integrity": "sha512-9uwQDhTFb7DP8dPXn6gbieptxPCkr9ADwgkej+1gXbXN/WZJZdkwSW970qrC6hIyd+sPTf2VV4QEQUzdqPSdFQ==",
       "dev": true,
       "requires": {
-        "@babel/generator": "^7.0.0-beta.38",
-        "@lingui/conf": "2.0.1"
+        "@lingui/conf": "2.1.0",
+        "babel-generator": "^6.26.1"
       }
     },
     "@lingui/babel-plugin-transform-js": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@lingui/babel-plugin-transform-js/-/babel-plugin-transform-js-2.0.1.tgz",
-      "integrity": "sha512-i8pFhwUWwUV14dMi6fgrGnpIf/S0TKGMGQiQksvm4Q8s8Zi/OaJli91rFjHvTdfZi+pevfX4+zP+wiuIx8I4qQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@lingui/babel-plugin-transform-js/-/babel-plugin-transform-js-2.1.0.tgz",
+      "integrity": "sha512-FXQGDNlgiLS7V43G3ucBP7pK+s9ZXjb8MiuyF+51EOjd5lYcXGfgP2kP6ng+DmZfIKav22J05qa4Ye8O1se21A==",
       "dev": true
     },
     "@lingui/babel-plugin-transform-react": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@lingui/babel-plugin-transform-react/-/babel-plugin-transform-react-2.0.1.tgz",
-      "integrity": "sha512-x3/Orf1HvHw+g1HKxurCxmc6WYNYqje+NnCjD1RQg8jCqogpdxabf2Z+mXG286jzyhwY+mz+6o9jFMyRrqvD3w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@lingui/babel-plugin-transform-react/-/babel-plugin-transform-react-2.1.0.tgz",
+      "integrity": "sha512-T3aZ0l+piiECd9uxdt4GZdSjO4wJ3S9pf9qJ10dWhIz61exT5qpnJpQ98j7scV84F4rgJqNRo0tecpUwEQl/mg==",
       "dev": true
     },
     "@lingui/babel-preset-react": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@lingui/babel-preset-react/-/babel-preset-react-2.0.1.tgz",
-      "integrity": "sha512-vpY8HO9HUByQFZTL0cTKa3vN+TRRe+icY1lVho5CuidgNuq/scv+Tw2DsPl4qDWbIHpQtFId89w6OKraEx4BeQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@lingui/babel-preset-react/-/babel-preset-react-2.1.0.tgz",
+      "integrity": "sha512-NMKXtxIjRoGpAvV65pNnvuqLTN1OHVSZg8sSVt0o2Gt2mtKx6wvJU94wKgTDn83QjzzR9g28TK1eaiyFE/EMVQ==",
       "dev": true,
       "requires": {
-        "@lingui/babel-plugin-transform-js": "2.0.1",
-        "@lingui/babel-plugin-transform-react": "2.0.1"
+        "@lingui/babel-plugin-transform-js": "2.1.0",
+        "@lingui/babel-plugin-transform-react": "2.1.0"
       }
     },
     "@lingui/cli": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@lingui/cli/-/cli-2.0.1.tgz",
-      "integrity": "sha512-ZzWA+a9uVcKAvn89dLFO6oSJUi6nlAE8nOTFfRlqOk5IB2BINnjRqAj55FCqNmL2+PEqwjT0T6qCz6G2PiUzEA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@lingui/cli/-/cli-2.1.0.tgz",
+      "integrity": "sha512-cI7O/GHk9fZiTbrYMRaGY/uHT96DrbjphSuBoZRXEPQGlAeqkSvXUvQBVrSIMak40pI6HrWx2i/eO6Mjlwhl9g==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.0.0-beta.38",
-        "@babel/generator": "^7.0.0-beta.38",
-        "@babel/runtime": "^7.0.0-beta.38",
-        "@babel/types": "^7.0.0-beta.38",
-        "@lingui/babel-plugin-extract-messages": "2.0.1",
-        "@lingui/babel-plugin-transform-js": "2.0.1",
-        "@lingui/babel-plugin-transform-react": "2.0.1",
-        "@lingui/conf": "2.0.1",
+        "@lingui/babel-plugin-extract-messages": "2.1.0",
+        "@lingui/babel-plugin-transform-js": "2.1.0",
+        "@lingui/babel-plugin-transform-react": "2.1.0",
+        "@lingui/conf": "2.1.0",
+        "babel-core": "^6.26.3",
+        "babel-generator": "^6.26.1",
+        "babel-plugin-transform-typescript": "^7.0.0-alpha.19",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
         "babylon": "^6.18.0",
         "chalk": "^2.3.0",
         "cli-table": "^0.3.1",
@@ -954,17 +946,23 @@
       }
     },
     "@lingui/conf": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@lingui/conf/-/conf-2.0.1.tgz",
-      "integrity": "sha512-e2ASNWhCB3PvT3Wpe83cfWnyKVbKr5lkpwH2K5uL55ROWOZLhw1yq+eYbhi8jb36y70n1dlqIdGqGVHpt8zfJA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@lingui/conf/-/conf-2.1.0.tgz",
+      "integrity": "sha512-Feh1VTbDQTYhqaveyQhOABRFwjjXRsVEBvYOlkWk9RraR/gebtrFmUKpk2AfGWNwV0XGyFsBOFVPM4d8qmwo2g==",
       "dev": true,
       "requires": {
         "chalk": "^2.3.0",
-        "jest-regex-util": "^22.1.0",
-        "jest-validate": "^22.1.2",
+        "jest-regex-util": "^23.0.0",
+        "jest-validate": "^23.0.1",
         "pkg-conf": "^2.1.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -985,6 +983,34 @@
             "supports-color": "^5.3.0"
           }
         },
+        "jest-regex-util": {
+          "version": "23.0.0",
+          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.0.0.tgz",
+          "integrity": "sha1-3Vwf3gxG9DcTFM8Q96dRoj9Oj3Y=",
+          "dev": true
+        },
+        "jest-validate": {
+          "version": "23.0.1",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.0.1.tgz",
+          "integrity": "sha1-zZ8BqJ0mu4hfEqhmdxXpyGWldU8=",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.1",
+            "jest-get-type": "^22.1.0",
+            "leven": "^2.1.0",
+            "pretty-format": "^23.0.1"
+          }
+        },
+        "pretty-format": {
+          "version": "23.0.1",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.0.1.tgz",
+          "integrity": "sha1-1h0GUmjkx1kIO8y8onoBrXx2AfQ=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0",
+            "ansi-styles": "^3.2.0"
+          }
+        },
         "supports-color": {
           "version": "5.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
@@ -997,22 +1023,22 @@
       }
     },
     "@lingui/core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-2.0.1.tgz",
-      "integrity": "sha512-5iOufrP1TqbAhHekd3LTmIA3+xh+/sVNIFUAPCJga5P/Na+vl7uSCrIXXaQ5PEhESLRjB8M2q0PW8a4hniNd/w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-WVmoWnTF7r0kiQfqok7tWzgf92OGP1d83SQ/J7vB2mZvG3Khb1An/IOXf6S6zhT/cVsD5zZZV5sWb7QeQyrZ/A==",
       "requires": {
-        "@babel/runtime": "^7.0.0-beta.38",
+        "babel-runtime": "^6.26.0",
         "make-plural": "^4.1.1",
         "messageformat-parser": "^2.0.0"
       }
     },
     "@lingui/react": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@lingui/react/-/react-2.0.1.tgz",
-      "integrity": "sha512-bREWOrnM2zaeQChLlEZPFkiGuxc8guPeaBf6QjguhZPk8a44+ZdVtFNjJ2WzhZZFQQrQDkSxrGtJmRQeec/V9g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@lingui/react/-/react-2.1.0.tgz",
+      "integrity": "sha512-s9Gt2WO1APUgIxnLNGjlkVYxYJlpejCebMr6rWrENC8Y2nZIKYqmHDg8sWZIx5AT7FqNPhI/Hu8Sjb0qceSmSQ==",
       "requires": {
-        "@babel/runtime": "^7.0.0-beta.38",
-        "@lingui/core": "2.0.1",
+        "@lingui/core": "2.1.0",
+        "babel-runtime": "^6.26.0",
         "hash-sum": "^1.0.2",
         "prop-types": "^15.6.0"
       }
@@ -1098,6 +1124,11 @@
       "integrity": "sha512-e74sM9W/4qqWB6D4TWV9FQk0WoHtX1X4FJpbjxucMSVJHtFjbQOH3H6yp+xno4br0AKG0wz/kPtaN599GUOvAg==",
       "dev": true
     },
+    "@types/markdown-it": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-0.0.4.tgz",
+      "integrity": "sha512-FWR7QB7EqBRq1s9BMk0ccOSOuRLfVEWYpHQYpFPaXtCoqN6dJx2ttdsdQbUxLLnAlKpYeVjveGGhQ3583TTa7g=="
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -1114,7 +1145,6 @@
       "version": "16.3.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.3.13.tgz",
       "integrity": "sha512-YMFH/E9ryjUm2AoOy8KdTuG1SufaMuYmO/5xACROl0pm9dRmE2RN3d2zjv/eHALF6LGRZPVb7G9kqP0n5dWttQ==",
-      "dev": true,
       "requires": {
         "csstype": "^2.2.0"
       }
@@ -1123,7 +1153,6 @@
       "version": "0.52.25",
       "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.52.25.tgz",
       "integrity": "sha512-JwrONoGfasRORI3QUILXar8xG9Q3rCS2EpfB2abGIvqWRISuRPKpjJOm4OL0tEBTPL/9r6hcngRrmYZSbvDDtw==",
-      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -1663,7 +1692,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -2182,6 +2210,12 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
       "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
     },
+    "babel-plugin-syntax-typescript": {
+      "version": "7.0.0-alpha.19",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-typescript/-/babel-plugin-syntax-typescript-7.0.0-alpha.19.tgz",
+      "integrity": "sha512-jLuaWfoQsVr8/hmZtWB+86tZ5jYmOYV6kq70EkSUT7RR+gfeYOExS0FjObbbp+WExZNpBaRZvlyikNk3hCQGeQ==",
+      "dev": true
+    },
     "babel-plugin-transform-async-to-generator": {
       "version": "6.16.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.16.0.tgz",
@@ -2481,6 +2515,15 @@
       "requires": {
         "babel-runtime": "^6.22.0",
         "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-typescript": {
+      "version": "7.0.0-alpha.19",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-typescript/-/babel-plugin-transform-typescript-7.0.0-alpha.19.tgz",
+      "integrity": "sha512-OtkOYcYRffmC38/UjDZn2cvM2qarqDT748TbSJtVpNb7EvDLQcfPn9+0adk8oqmhc0lk+Ldy/2daGMNMxW0vuQ==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-typescript": "7.0.0-alpha.19"
       }
     },
     "babel-polyfill": {
@@ -3714,8 +3757,7 @@
     "csstype": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.4.2.tgz",
-      "integrity": "sha512-1TnkyZwDy0oUl//6685j2bTMNe61SzntWntijNdmmEzvpYbGmVMZkj204gv4glcQp6z/ypg+YRziT91XVFmOyg==",
-      "dev": true
+      "integrity": "sha512-1TnkyZwDy0oUl//6685j2bTMNe61SzntWntijNdmmEzvpYbGmVMZkj204gv4glcQp6z/ypg+YRziT91XVFmOyg=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -4065,12 +4107,6 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
-    "ejs": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
-      "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==",
-      "dev": true
-    },
     "electron": {
       "version": "1.4.16",
       "resolved": "https://registry.npmjs.org/electron/-/electron-1.4.16.tgz",
@@ -4138,8 +4174,7 @@
     "entities": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
-      "dev": true
+      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
     },
     "envinfo": {
       "version": "3.11.1",
@@ -4389,12 +4424,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-      "dev": true
-    },
-    "exit-hook": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
       "dev": true
     },
     "exp": {
@@ -5725,12 +5754,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
-    },
-    "get-params": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/get-params/-/get-params-0.1.2.tgz",
-      "integrity": "sha1-uuDfq6WIoMYNeDTA2Nwv9g7u8v4=",
-      "dev": true
     },
     "get-stdin": {
       "version": "4.0.1",
@@ -8304,6 +8327,14 @@
       "integrity": "sha1-eYsP+X0bkqT9CEgPVa6k6dSdN78=",
       "dev": true
     },
+    "linkify-it": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.0.3.tgz",
+      "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
+      "requires": {
+        "uc.micro": "^1.0.1"
+      }
+    },
     "load-json-file": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
@@ -8610,6 +8641,18 @@
         "object-visit": "^1.0.0"
       }
     },
+    "markdown-it": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.1.tgz",
+      "integrity": "sha512-CzzqSSNkFRUf9vlWvhK1awpJreMRqdCrBvZ8DIoDWTOkESMIF741UPAhuAmbyWmdiFPA6WARNhnu2M6Nrhwa+A==",
+      "requires": {
+        "argparse": "^1.0.7",
+        "entities": "~1.1.1",
+        "linkify-it": "^2.0.0",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      }
+    },
     "match-require": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/match-require/-/match-require-2.1.0.tgz",
@@ -8643,6 +8686,11 @@
       "resolved": "https://registry.npmjs.org/md5hex/-/md5hex-1.0.0.tgz",
       "integrity": "sha1-7XS0d6Luk2n3Xv7i8I1ZFeUqQug=",
       "dev": true
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -10759,6 +10807,14 @@
         "lodash": "^4.11.1"
       }
     },
+    "react-native-fit-image": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/react-native-fit-image/-/react-native-fit-image-1.5.4.tgz",
+      "integrity": "sha512-wNHlGdDWsUU31qlM5SsvZrMH4eXBZt586FQNXFRFuOiXVqdA++6Xait7aiZ+5vxglgqLf+zzSnoICn0NEvDfrw==",
+      "requires": {
+        "prop-types": "^15.5.10"
+      }
+    },
     "react-native-gesture-handler": {
       "version": "1.0.0-alpha.41",
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-1.0.0-alpha.41.tgz",
@@ -10836,6 +10892,18 @@
             "react-transform-hmr": "^1.0.4"
           }
         }
+      }
+    },
+    "react-native-markdown-renderer": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/react-native-markdown-renderer/-/react-native-markdown-renderer-3.2.6.tgz",
+      "integrity": "sha512-/CNYpMX37pt/yFofSZgbNiRGMIuMeRXvoWeDVt7YT2ZrS/nqEECohyn8bFyDnDN3FgOnYU+D3k0kM2UxwU0K7w==",
+      "requires": {
+        "@types/markdown-it": "^0.0.4",
+        "@types/react-native": ">=0.50.0",
+        "markdown-it": "^8.4.0",
+        "prop-types": "^15.5.10",
+        "react-native-fit-image": "^1.5.2"
       }
     },
     "react-native-safe-module": {
@@ -12488,8 +12556,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.14.1",
@@ -13651,6 +13718,11 @@
       "version": "0.7.18",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
       "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
+    },
+    "uc.micro": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.5.tgz",
+      "integrity": "sha512-JoLI4g5zv5qNyT09f4YAvEZIIV1oOjqnewYg5D38dkQljIzpPT296dbIGvKro3digYI1bkb7W6EP1y4uDlmzLg=="
     },
     "uglify-es": {
       "version": "3.3.9",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "devDependencies": {
-    "@lingui/babel-preset-react": "2.0.1",
-    "@lingui/cli": "2.0.1",
+    "@lingui/babel-preset-react": "2.1.0",
+    "@lingui/cli": "2.1.0",
     "@types/enzyme": "^3.1.9",
     "@types/enzyme-adapter-react-16": "^1.0.2",
     "@types/expo": "^26.0.0",
@@ -75,7 +75,7 @@
     ]
   },
   "dependencies": {
-    "@lingui/react": "2.0.1",
+    "@lingui/react": "2.1.0",
     "expo": "^27.0.0",
     "history": "^4.7.2",
     "intl": "^1.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,7 +8,7 @@
   dependencies:
     "@babel/highlight" "7.0.0-beta.49"
 
-"@babel/core@^7.0.0-beta", "@babel/core@^7.0.0-beta.38":
+"@babel/core@^7.0.0-beta":
   version "7.0.0-beta.49"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.0.0-beta.49.tgz#73de2081dd652489489f0cb4aa97829a1133314e"
   dependencies:
@@ -28,7 +28,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@7.0.0-beta.49", "@babel/generator@^7.0.0-beta", "@babel/generator@^7.0.0-beta.38":
+"@babel/generator@7.0.0-beta.49", "@babel/generator@^7.0.0-beta":
   version "7.0.0-beta.49"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0-beta.49.tgz#e9cffda913996accec793bbc25ab91bc19d0bf7a"
   dependencies:
@@ -402,13 +402,6 @@
     pirates "^3.0.1"
     source-map-support "^0.4.2"
 
-"@babel/runtime@^7.0.0-beta.38":
-  version "7.0.0-beta.49"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.49.tgz#03b3bf07eb982072c8e851dd2ddd5110282e61bf"
-  dependencies:
-    core-js "^2.5.6"
-    regenerator-runtime "^0.11.1"
-
 "@babel/template@7.0.0-beta.49", "@babel/template@^7.0.0-beta":
   version "7.0.0-beta.49"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.49.tgz#e38abe8217cb9793f461a5306d7ad745d83e1d27"
@@ -433,7 +426,7 @@
     invariant "^2.2.0"
     lodash "^4.17.5"
 
-"@babel/types@7.0.0-beta.49", "@babel/types@^7.0.0-beta", "@babel/types@^7.0.0-beta.38":
+"@babel/types@7.0.0-beta.49", "@babel/types@^7.0.0-beta":
   version "7.0.0-beta.49"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.49.tgz#b7e3b1c3f4d4cfe11bdf8c89f1efd5e1617b87a6"
   dependencies:
@@ -595,40 +588,41 @@
     pouchdb-collections "^1.0.1"
     tiny-queue "^0.2.1"
 
-"@lingui/babel-plugin-extract-messages@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@lingui/babel-plugin-extract-messages/-/babel-plugin-extract-messages-2.0.1.tgz#7d89e536c9d79086bebd86f029c11a40dd5ded52"
+"@lingui/babel-plugin-extract-messages@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@lingui/babel-plugin-extract-messages/-/babel-plugin-extract-messages-2.1.0.tgz#9b09c4b544ab55bf5cf45654ece839a18625c6ca"
   dependencies:
-    "@babel/generator" "^7.0.0-beta.38"
-    "@lingui/conf" "2.0.1"
+    "@lingui/conf" "2.1.0"
+    babel-generator "^6.26.1"
 
-"@lingui/babel-plugin-transform-js@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@lingui/babel-plugin-transform-js/-/babel-plugin-transform-js-2.0.1.tgz#463a44d31854d45823d8539d137382f88bb2a5df"
+"@lingui/babel-plugin-transform-js@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@lingui/babel-plugin-transform-js/-/babel-plugin-transform-js-2.1.0.tgz#3cda87a1d84a7486c6b4328aa2bb5ef6aea460a1"
 
-"@lingui/babel-plugin-transform-react@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@lingui/babel-plugin-transform-react/-/babel-plugin-transform-react-2.0.1.tgz#0cf0c799c5f6ba59424548fdcbfe59d9d855f722"
+"@lingui/babel-plugin-transform-react@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@lingui/babel-plugin-transform-react/-/babel-plugin-transform-react-2.1.0.tgz#3db2be2c7176544f68bdf07b9f8293c53a4fb73e"
 
-"@lingui/babel-preset-react@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@lingui/babel-preset-react/-/babel-preset-react-2.0.1.tgz#4baaff311feebd79411736f9db5aef9d1f193e32"
+"@lingui/babel-preset-react@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@lingui/babel-preset-react/-/babel-preset-react-2.1.0.tgz#9a42067db3236b4464c0b9fcdf64b54a515cef38"
   dependencies:
-    "@lingui/babel-plugin-transform-js" "2.0.1"
-    "@lingui/babel-plugin-transform-react" "2.0.1"
+    "@lingui/babel-plugin-transform-js" "2.1.0"
+    "@lingui/babel-plugin-transform-react" "2.1.0"
 
-"@lingui/cli@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@lingui/cli/-/cli-2.0.1.tgz#6025551b86f6e71ba3aa76c0d0847c38dfb44bd9"
+"@lingui/cli@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@lingui/cli/-/cli-2.1.0.tgz#cbfea4c0f95dc9d1fde812a4411e1fc1110fd8c0"
   dependencies:
-    "@babel/core" "^7.0.0-beta.38"
-    "@babel/generator" "^7.0.0-beta.38"
-    "@babel/runtime" "^7.0.0-beta.38"
-    "@babel/types" "^7.0.0-beta.38"
-    "@lingui/babel-plugin-extract-messages" "2.0.1"
-    "@lingui/babel-plugin-transform-js" "2.0.1"
-    "@lingui/babel-plugin-transform-react" "2.0.1"
-    "@lingui/conf" "2.0.1"
+    "@lingui/babel-plugin-extract-messages" "2.1.0"
+    "@lingui/babel-plugin-transform-js" "2.1.0"
+    "@lingui/babel-plugin-transform-react" "2.1.0"
+    "@lingui/conf" "2.1.0"
+    babel-core "^6.26.3"
+    babel-generator "^6.26.1"
+    babel-plugin-transform-typescript "^7.0.0-alpha.19"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
     babylon "^6.18.0"
     chalk "^2.3.0"
     cli-table "^0.3.1"
@@ -639,29 +633,29 @@
     mkdirp "^0.5.1"
     ramda "^0.25.0"
 
-"@lingui/conf@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@lingui/conf/-/conf-2.0.1.tgz#f2f8a468a9ed540d99941cbe62062cac8764d23f"
+"@lingui/conf@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@lingui/conf/-/conf-2.1.0.tgz#08857ada6901880dcd6b88df0ca8004f4de6bdb3"
   dependencies:
     chalk "^2.3.0"
-    jest-regex-util "^22.1.0"
-    jest-validate "^22.1.2"
+    jest-regex-util "^23.0.0"
+    jest-validate "^23.0.1"
     pkg-conf "^2.1.0"
 
-"@lingui/core@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@lingui/core/-/core-2.0.1.tgz#013b11194c5c7672e91d0fa6d190f377ea2a579f"
+"@lingui/core@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@lingui/core/-/core-2.1.0.tgz#69d7b2bf16888653c2156e3bdf5a614351d89a27"
   dependencies:
-    "@babel/runtime" "^7.0.0-beta.38"
+    babel-runtime "^6.26.0"
     make-plural "^4.1.1"
     messageformat-parser "^2.0.0"
 
-"@lingui/react@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@lingui/react/-/react-2.0.1.tgz#ee6f82a54945979c95857a0859f2cc90e4015530"
+"@lingui/react@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@lingui/react/-/react-2.1.0.tgz#c79d3b7930ac9352aec5e82b690d4af7bd07738c"
   dependencies:
-    "@babel/runtime" "^7.0.0-beta.38"
-    "@lingui/core" "2.0.1"
+    "@lingui/core" "2.1.0"
+    babel-runtime "^6.26.0"
     hash-sum "^1.0.2"
     prop-types "^15.6.0"
 
@@ -1179,7 +1173,7 @@ babel-core@^6.0.0, babel-core@^6.24.1, babel-core@^6.26.0, babel-core@^6.26.2, b
     slash "^1.0.0"
     source-map "^0.5.7"
 
-babel-generator@^6.18.0, babel-generator@^6.26.0:
+babel-generator@^6.18.0, babel-generator@^6.26.0, babel-generator@^6.26.1:
   version "6.26.1"
   resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.1.tgz#1844408d3b8f0d35a404ea7ac180f087a601bd90"
   dependencies:
@@ -1398,6 +1392,10 @@ babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-
 babel-plugin-syntax-trailing-function-commas@^6.20.0, babel-plugin-syntax-trailing-function-commas@^6.5.0, babel-plugin-syntax-trailing-function-commas@^6.8.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
+
+babel-plugin-syntax-typescript@7.0.0-alpha.19:
+  version "7.0.0-alpha.19"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-typescript/-/babel-plugin-syntax-typescript-7.0.0-alpha.19.tgz#fc5876863db297549f5d840d248eac3310241f84"
 
 babel-plugin-transform-async-to-generator@6.16.0:
   version "6.16.0"
@@ -1635,6 +1633,12 @@ babel-plugin-transform-strict-mode@^6.24.1:
   dependencies:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
+
+babel-plugin-transform-typescript@^7.0.0-alpha.19:
+  version "7.0.0-alpha.19"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-typescript/-/babel-plugin-transform-typescript-7.0.0-alpha.19.tgz#9b06c066393d6752e6e539e8b0b5929a78feb5b1"
+  dependencies:
+    babel-plugin-syntax-typescript "7.0.0-alpha.19"
 
 babel-polyfill@^6.23.0:
   version "6.26.0"
@@ -4617,6 +4621,10 @@ jest-regex-util@^22.1.0, jest-regex-util@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-22.4.3.tgz#a826eb191cdf22502198c5401a1fc04de9cef5af"
 
+jest-regex-util@^23.0.0:
+  version "23.0.0"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-23.0.0.tgz#dd5c1fde0c46f4371314cf10f7a751a23f4e8f76"
+
 jest-resolve-dependencies@^22.1.0:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-22.4.3.tgz#e2256a5a846732dc3969cb72f3c9ad7725a8195e"
@@ -4698,7 +4706,7 @@ jest-util@^22.4.1, jest-util@^22.4.3:
     mkdirp "^0.5.1"
     source-map "^0.6.0"
 
-jest-validate@^22.1.2, jest-validate@^22.4.4:
+jest-validate@^22.4.4:
   version "22.4.4"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-22.4.4.tgz#1dd0b616ef46c995de61810d85f57119dbbcec4d"
   dependencies:
@@ -4707,6 +4715,15 @@ jest-validate@^22.1.2, jest-validate@^22.4.4:
     jest-get-type "^22.1.0"
     leven "^2.1.0"
     pretty-format "^22.4.0"
+
+jest-validate@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-23.0.1.tgz#cd9f01a89d26bb885f12a8667715e9c865a5754f"
+  dependencies:
+    chalk "^2.0.1"
+    jest-get-type "^22.1.0"
+    leven "^2.1.0"
+    pretty-format "^23.0.1"
 
 jest-worker@22.2.2:
   version "22.2.2"
@@ -6271,6 +6288,13 @@ pretty-format@^22.4.0, pretty-format@^22.4.3:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
+pretty-format@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.0.1.tgz#d61d065268e4c759083bccbca27a01ad7c7601f4"
+  dependencies:
+    ansi-regex "^3.0.0"
+    ansi-styles "^3.2.0"
+
 pretty-format@^4.2.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-4.3.1.tgz#530be5c42b3c05b36414a7a2a4337aa80acd0e8d"
@@ -6936,7 +6960,7 @@ regenerator-runtime@^0.10.5:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
-regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
+regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 


### PR DESCRIPTION
Updates to jsLingui 2.1.0 (which resolves the Babel dependency issue).