### PR TITLE
Issue #119 Upgrade native-base to 2.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "expo": "^27.0.0",
     "history": "^4.7.2",
     "intl": "^1.2.5",
-    "native-base": "affinitybridge/NativeBase",
+    "native-base": "^2.5.2",
     "react": "16.3.1",
     "react-native": "^0.55.0",
     "react-native-collapsible": "^0.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5633,9 +5633,9 @@ native-base-shoutem-theme@0.2.2:
     lodash "^4.10.1"
     prop-types "^15.5.10"
 
-native-base@affinitybridge/NativeBase:
-  version "2.5.1"
-  resolved "https://codeload.github.com/affinitybridge/NativeBase/tar.gz/41369f688b6ef5e6be297ab4443445ca9312eb17"
+native-base@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/native-base/-/native-base-2.5.2.tgz#62d2a0a8d4d1e0384bcc07f36845bdf256930a9f"
   dependencies:
     blueimp-md5 "^2.5.0"
     clamp "^1.0.1"


### PR DESCRIPTION
This fixes the need for our forked version of the native-base library.