### PR TITLE
Issue #157 Remove hardcoded service data

### DIFF
--- a/src/api/api_client.ts
+++ b/src/api/api_client.ts
@@ -21,7 +21,7 @@ export class APIClient {
     }
 
     async searchServices(query: string): Promise<APIResponse> {
-        const endpoint = 'services';
+        const endpoint = 'services_at_location';
         const servicesResponse = await this.fetch(endpoint, { search: query });
         // TODO: Consider collecting and fetching associated entities
         //       (organizations and locations).

--- a/src/components/services/service.tsx
+++ b/src/components/services/service.tsx
@@ -1,14 +1,17 @@
 import React from 'react';
+import * as R from 'ramda';
 import { applicationStyles } from '../../application/styles';
 import { Service } from '../../selectors/services/service';
 import { View } from 'native-base';
 import { Text } from 'react-native';
+import { PhoneNumber } from '../../stores/services/types';
 
 interface Props {
     readonly service: Service;
 }
 
 export function ServiceComponent(props: Props): JSX.Element {
+    const mapWithIndex = R.addIndex(R.map);
     return (
         <View>
             <Text style={[
@@ -17,9 +20,13 @@ export function ServiceComponent(props: Props): JSX.Element {
             ]}>
                 {props.service.name}
             </Text>
-            <Text style={[{ textAlign: 'left' }]}><Text style={{ color: 'darkgrey' }}>Address: </Text>123 Main St, Vancouver BC</Text>
-            <Text style={[{ textAlign: 'left' }]}><Text style={{ color: 'darkgrey' }}>Hours: </Text>Mon - Fri: 9:00am - 5:00pm</Text>
-            {/* <Text>{props.service.description}</Text> */}
+            {
+                mapWithIndex((phoneNumber: PhoneNumber, index: number) =>
+                    <View key={index}>
+                        <Text>{phoneNumber.type}</Text>
+                        <Text>{phoneNumber.phoneNumber}</Text>
+                    </View>, props.service.phoneNumbers)
+            }
         </View>
     );
 }

--- a/src/selectors/services/select_task_services.ts
+++ b/src/selectors/services/select_task_services.ts
@@ -19,6 +19,7 @@ export function selectTaskServices(taskId: TaskId, store: Store): TaskServices {
                 id: service.id,
                 name: getLocalizedText(locale, service.name),
                 description: getLocalizedText(locale, service.description),
+                phoneNumbers: service.phoneNumbers,
             };
         }),
     };

--- a/src/selectors/services/service.ts
+++ b/src/selectors/services/service.ts
@@ -1,5 +1,8 @@
+import { PhoneNumber } from '../../stores/services/types';
+
 export interface Service {
     readonly id: string;
     readonly name: string;
     readonly description: string;
+    readonly phoneNumbers: ReadonlyArray<PhoneNumber>;
 }

--- a/src/stores/__tests__/helpers/services_helpers.ts
+++ b/src/stores/__tests__/helpers/services_helpers.ts
@@ -2,7 +2,7 @@
 import { aString } from '../../../application/__tests__/helpers/random_test_values';
 import { Id } from '../../services';
 import { Id as TaskId } from '../../tasks';
-import { TaskServices, Service, TaskServicesMap, ServiceMap, ServiceStore } from '../../services/types';
+import { TaskServices, Service, TaskServicesMap, ServiceMap, ServiceStore, PhoneNumber } from '../../services/types';
 import { LocalizedText } from '../../../locale';
 import { LocalizedTextBuilder } from './locale_helpers';
 
@@ -28,10 +28,37 @@ function buildTaskServicesMap(tasks: ReadonlyArray<TaskServicesBuilder>, service
     return tasks.reduce(buildAndMapToId, {});
 }
 
+export class PhoneNumberBuilder {
+    static buildArray(length: number = 3): ReadonlyArray<PhoneNumber> {
+        return Array(length).fill(new PhoneNumberBuilder().build());
+    }
+
+    type: string = aString();
+    phoneNumber: string = aString();
+
+    withType(type: string): PhoneNumberBuilder {
+        this.type = type;
+        return this;
+    }
+
+    withPhoneNumber(phoneNumber: string): PhoneNumberBuilder {
+        this.phoneNumber = phoneNumber;
+        return this;
+    }
+
+    build(): PhoneNumber {
+        return {
+            type: this.type,
+            phoneNumber: this.phoneNumber,
+        };
+    }
+}
+
 export class ServiceBuilder {
     id: Id = aString();
     name: LocalizedText = new LocalizedTextBuilder().build();
     description: LocalizedText = new LocalizedTextBuilder().build();
+    phoneNumbers: ReadonlyArray<PhoneNumber> = PhoneNumberBuilder.buildArray();
 
     withId(id: Id): ServiceBuilder {
         this.id = id;
@@ -48,11 +75,17 @@ export class ServiceBuilder {
         return this;
     }
 
+    withPhoneNumbers(phoneNumbers: ReadonlyArray<PhoneNumber>): ServiceBuilder {
+        this.phoneNumbers = phoneNumbers;
+        return this;
+    }
+
     build(): Service {
         return {
             id: this.id,
             name: this.name,
             description: this.description,
+            phoneNumbers: this.phoneNumbers,
         };
     }
 }

--- a/src/stores/services/index.ts
+++ b/src/stores/services/index.ts
@@ -1,6 +1,7 @@
+import * as R from 'ramda';
 import { LocalizedText } from '../../locale';
 
-import { Id, Service, ServiceStore, ServiceMap, TaskServices } from './types';
+import { Id, Service, ServiceStore, ServiceMap, TaskServices, PhoneNumber, APIPhoneNumber } from './types';
 import { UpdateTaskServicesAsync, updateTaskServicesAsync } from './update_task_services';
 import * as constants from '../../application/constants';
 import { Action } from 'redux';
@@ -11,10 +12,19 @@ export { UpdateTaskServicesAsync, updateTaskServicesAsync };
 export function serviceFromServiceData(data: any): Service { // tslint:disable-line:no-any
     // TODO: Perform appropriate data validation.
     //       Alternatively bring in a tool to do this for us, eg: Serializr
-    const id: string = data.id || undefined;
-    const name: LocalizedText = { 'en': data.name || '' };
-    const description: LocalizedText = { 'en': data.description || '' };
-    return { id, name, description };
+    const id: string = data.service.id || undefined;
+    const name: LocalizedText = { 'en': data.service.name || '' };
+    const description: LocalizedText = { 'en': data.service.description || '' };
+    const phoneNumbers: ReadonlyArray<PhoneNumber> = data.location.phone_numbers ?
+        APIPhoneNumbersToStorePhoneNumbers(data.location.phone_numbers) : [];
+    return { id, name, description, phoneNumbers };
+}
+
+function APIPhoneNumbersToStorePhoneNumbers(phoneNumbers: ReadonlyArray<APIPhoneNumber>): ReadonlyArray<PhoneNumber> {
+    return R.map((phoneNumber: APIPhoneNumber): PhoneNumber => ({
+        type: phoneNumber.phone_number_type,
+        phoneNumber: phoneNumber.phone_number,
+    }), phoneNumbers);
 }
 
 function buildDefaultStore(): ServiceStore {

--- a/src/stores/services/types.ts
+++ b/src/stores/services/types.ts
@@ -2,10 +2,21 @@ import { LocalizedText } from '../../locale';
 
 export type Id = string;
 
+export interface APIPhoneNumber {
+    readonly phone_number_type: string;
+    readonly phone_number: string;
+}
+
+export interface PhoneNumber {
+    readonly type: string;
+    readonly phoneNumber: string;
+}
+
 export interface Service {
     readonly id: Id;
     readonly name: LocalizedText;
     readonly description: LocalizedText;
+    readonly phoneNumbers: ReadonlyArray<PhoneNumber>;
 }
 
 export interface TaskServices {


### PR DESCRIPTION
This PR has an associated backend PR: https://github.com/pg-irc/pathways-backend/pull/242

This PR pulls in phone number data from the services_at_locations endpoint and removes anything hardcoded. Visually it will need further work. Implementation wise it is very basic as the AC was somewhat light. I expect this to evolve and also feel it's likely worth looking into tools like serialzr to better convert between our API responses and their associated TS Objects.