### PR TITLE
Clean up task service implementation

### DIFF
--- a/src/components/services/service.tsx
+++ b/src/components/services/service.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 export function ServiceComponent(props: Props): JSX.Element {
     const mapWithIndex = R.addIndex(R.map);
-
+    const physicalAddresses = R.filter(R.propEq('type', 'physical_address'), props.service.addresses);
     const capitalizeFirstLetter = (phoneType: string): string => (
         phoneType.charAt(0).toUpperCase() + phoneType.slice(1)
     );
@@ -29,7 +29,7 @@ export function ServiceComponent(props: Props): JSX.Element {
                 mapWithIndex((address: Address, index: number) =>
                     <View key={index}>
                         <Text>{address.address}</Text>
-                    </View>, props.service.addresses)
+                    </View>, physicalAddresses)
             }
             {
                 mapWithIndex((phoneNumber: PhoneNumber, index: number) =>

--- a/src/components/services/service.tsx
+++ b/src/components/services/service.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import * as R from 'ramda';
 import { applicationStyles, colors } from '../../application/styles';
-import { Service, Address } from '../../stores/services';
+import { Service, PhoneNumber, Address } from '../../stores/services';
 import { View } from 'native-base';
 import { Text } from 'react-native';
-import { PhoneNumber } from '../../stores/services';
 import { TextWithPhoneLinks } from '../link/text_with_phone_links';
 
 interface Props {
@@ -18,10 +17,6 @@ export function ServiceComponent(props: Props): JSX.Element {
         phoneType.charAt(0).toUpperCase() + phoneType.slice(1)
     );
 
-    const getAddress = (address: Address): string => (
-        address === null ? '' : address.address
-    );
-
     return (
         <View>
             <Text style={[
@@ -30,7 +25,12 @@ export function ServiceComponent(props: Props): JSX.Element {
             ]}>
                 {props.service.name}
             </Text>
-            <Text>{getAddress(props.service.physicalAddress)}</Text>
+            {
+                mapWithIndex((address: Address, index: number) =>
+                    <View key={index}>
+                        <Text>{address.address}</Text>
+                    </View>, props.service.addresses)
+            }
             {
                 mapWithIndex((phoneNumber: PhoneNumber, index: number) =>
                     <View key={index}>

--- a/src/stores/__tests__/helpers/services_helpers.ts
+++ b/src/stores/__tests__/helpers/services_helpers.ts
@@ -2,8 +2,7 @@
 import { aString } from '../../../application/__tests__/helpers/random_test_values';
 import { Id } from '../../services';
 import { Id as TaskId } from '../../tasks';
-import { TaskServices, Service, TaskServicesMap, ServiceMap, ServiceStore, PhoneNumber, Address, AddressWithType } from '../../services/types';
-
+import { TaskServices, Service, TaskServicesMap, ServiceMap, ServiceStore, PhoneNumber, Address } from '../../services/types';
 
 export function buildNormalizedServices(tasks: ReadonlyArray<TaskServicesBuilder>, services: ReadonlyArray<ServiceBuilder>): ServiceStore {
     return {
@@ -28,10 +27,6 @@ function buildTaskServicesMap(tasks: ReadonlyArray<TaskServicesBuilder>, service
 }
 
 export class PhoneNumberBuilder {
-    static buildArray(length: number = 3): ReadonlyArray<PhoneNumber> {
-        return Array(length).fill(new PhoneNumberBuilder().build());
-    }
-
     type: string = aString();
     phoneNumber: string = aString();
 
@@ -55,32 +50,20 @@ export class PhoneNumberBuilder {
 
 export class AddressBuilder {
     type: string = aString();
-
     address: string = aString();
     city: string = aString();
-    state_province: string = aString();
-    postal_code: string = aString();
+    province: string = aString();
+    postalCode: string = aString();
     country: string = aString();
-
-    withType(type: string): AddressBuilder {
-        this.type = type;
-        return this;
-    }
 
     build(): Address {
         return {
+            type: this.type,
             address: this.address,
             city: this.city,
-            state_province: this.state_province,
-            postal_code: this.postal_code,
+            province: this.province,
+            postalCode: this.postalCode,
             country: this.country,
-        };
-    }
-
-    buildWithType(): AddressWithType {
-        return {
-            type: this.type,
-            address: this.build(),
         };
     }
 }
@@ -89,9 +72,8 @@ export class ServiceBuilder {
     id: Id = aString();
     name: string = aString();
     description: string = aString();
-    phoneNumbers: ReadonlyArray<PhoneNumber> = PhoneNumberBuilder.buildArray();
-    physicalAddress: Address = new AddressBuilder().build();
-    postalAddress: Address = new AddressBuilder().build();
+    phoneNumbers: ReadonlyArray<PhoneNumber> = [];
+    addresses: ReadonlyArray<Address> = [];
 
     withId(id: Id): ServiceBuilder {
         this.id = id;
@@ -113,13 +95,8 @@ export class ServiceBuilder {
         return this;
     }
 
-    withPhysicalAddress(address: Address): ServiceBuilder {
-        this.physicalAddress = address;
-        return this;
-    }
-
-    withPostalAddress(address: Address): ServiceBuilder {
-        this.postalAddress = address;
+    withAddresses(addresses: ReadonlyArray<Address>): ServiceBuilder {
+        this.addresses = addresses;
         return this;
     }
 
@@ -129,8 +106,7 @@ export class ServiceBuilder {
             name: this.name,
             description: this.description,
             phoneNumbers: this.phoneNumbers,
-            physicalAddress: this.physicalAddress,
-            postalAddress: this.postalAddress,
+            addresses: this.addresses,
         };
     }
 }

--- a/src/stores/__tests__/helpers/services_helpers.ts
+++ b/src/stores/__tests__/helpers/services_helpers.ts
@@ -52,7 +52,7 @@ export class AddressBuilder {
     type: string = aString();
     address: string = aString();
     city: string = aString();
-    province: string = aString();
+    stateProvince: string = aString();
     postalCode: string = aString();
     country: string = aString();
 
@@ -61,7 +61,7 @@ export class AddressBuilder {
             type: this.type,
             address: this.address,
             city: this.city,
-            province: this.province,
+            stateProvince: this.stateProvince,
             postalCode: this.postalCode,
             country: this.country,
         };

--- a/src/stores/services/index.ts
+++ b/src/stores/services/index.ts
@@ -20,19 +20,17 @@ export function serviceFromValidatedJSON(data: ValidatedServiceAtLocationJSON): 
         type: addressWithType.address_type,
         address: addressWithType.address.address,
         city: addressWithType.address.city,
-        province: addressWithType.address.state_province,
+        stateProvince: addressWithType.address.state_province,
         postalCode: addressWithType.address.postal_code,
         country: addressWithType.address.country,
     }), data.location.addresses);
-
-    const physicalAddresses = R.filter(R.propEq('type', 'physical_address'), addresses);
 
     return {
         id: data.service.id,
         name: data.service.name,
         description: data.service.description,
         phoneNumbers: phoneNumbers,
-        addresses: physicalAddresses,
+        addresses: addresses,
     };
 }
 

--- a/src/stores/services/index.ts
+++ b/src/stores/services/index.ts
@@ -3,10 +3,10 @@ import * as constants from '../../application/constants';
 import { Id, Service, ServiceStore, ServiceMap, TaskServices, PhoneNumber } from './types';
 import { UpdateTaskServicesAsync, updateTaskServicesAsync } from './update_task_services';
 import { Action } from 'redux';
-import { ValidatedPhoneNumberJSON, ValidatedServiceAtLocationJSON, ValidatedAddressJSON, AddressWithType, Address } from './types';
+import { ValidatedPhoneNumberJSON, ValidatedServiceAtLocationJSON, ValidatedAddressWithTypeJSON, Address } from './types';
 import { serviceAtLocation, serviceAtLocationArray } from './schemas';
 
-export { Id, Service, ServiceStore, PhoneNumber, AddressWithType, Address };
+export { Id, Service, ServiceStore, PhoneNumber, Address };
 export { UpdateTaskServicesAsync, updateTaskServicesAsync };
 export { serviceAtLocation, serviceAtLocationArray };
 
@@ -16,30 +16,23 @@ export function serviceFromValidatedJSON(data: ValidatedServiceAtLocationJSON): 
          phoneNumber: phoneNumber.phone_number,
      }), data.location.phone_numbers);
 
-    const addressesWithType = R.map((address: ValidatedAddressJSON): AddressWithType => ({
-        type: address.address_type,
-        address: address.address,
+    const addresses = R.map((addressWithType: ValidatedAddressWithTypeJSON): Address => ({
+        type: addressWithType.address_type,
+        address: addressWithType.address.address,
+        city: addressWithType.address.city,
+        province: addressWithType.address.state_province,
+        postalCode: addressWithType.address.postal_code,
+        country: addressWithType.address.country,
     }), data.location.addresses);
 
-    const ADDRESS_TYPE_PHYSICAL = "physical_address";
-    const ADDRESS_TYPE_POSTAL = "postal_address";
-    var physicalAddress: Address = null;
-    var postalAddress: Address = null;
-    addressesWithType.forEach(element => {
-        if (element.type.match(ADDRESS_TYPE_PHYSICAL)) {
-            physicalAddress = element.address;
-        }else if (element.type.match(ADDRESS_TYPE_POSTAL)) {
-            postalAddress = element.address;
-        }
-    });
+    const physicalAddresses = R.filter(R.propEq('type', 'physical_address'), addresses);
 
     return {
         id: data.service.id,
         name: data.service.name,
         description: data.service.description,
         phoneNumbers: phoneNumbers,
-        physicalAddress: physicalAddress,
-        postalAddress: postalAddress,
+        addresses: physicalAddresses,
     };
 }
 

--- a/src/stores/services/schemas.ts
+++ b/src/stores/services/schemas.ts
@@ -14,6 +14,7 @@ const service = {
     },
     "required": ["id", "name", "description"]
 };
+
 const phoneNumber = {
     "type": "object",
     "properties": {
@@ -26,10 +27,12 @@ const phoneNumber = {
     },
     "required": ["phone_number_type", "phone_number"]
 };
+
 const phoneNumberArray = {
     "type": "array",
     "items": phoneNumber
 };
+
 const address = {
     "type": "object",
     "properties": {
@@ -54,6 +57,7 @@ const address = {
     },
     "required": ["id", "address", "city", "state_province", "postal_code", "country"]
 };
+
 const addressWithType = {
     "type": "object",
     "properties": {
@@ -64,18 +68,21 @@ const addressWithType = {
     },
     "required": ["address_type", "address"]
 };
-const addressArray = {
+
+const addressWithTypeArray = {
     "type": "array",
     "items": addressWithType
 };
+
 const location = {
     "type": "object",
     "properties": {
         "phone_numbers": phoneNumberArray,
-        "addresses": addressArray
+        "addresses": addressWithTypeArray
     },
     "required": ["phone_numbers", "addresses"]
 };
+
 export const serviceAtLocation = {
     "type": "object",
     "properties": {
@@ -84,8 +91,8 @@ export const serviceAtLocation = {
     },
     "required": ["service", "location"]
 };
+
 export const serviceAtLocationArray = {
     "type": "array",
     "items": serviceAtLocation
 };
-//# sourceMappingURL=schemas.js.map

--- a/src/stores/services/types.ts
+++ b/src/stores/services/types.ts
@@ -6,16 +6,12 @@ export interface PhoneNumber {
 }
 
 export interface Address {
+    readonly type: string;
     readonly address: string;
     readonly city: string;
-    readonly state_province: string;
-    readonly postal_code: string;
+    readonly province: string;
+    readonly postalCode: string;
     readonly country: string;
-}
-
-export interface AddressWithType {
-    readonly type: string;
-    readonly address: Address;
 }
 
 export interface Service {
@@ -23,8 +19,7 @@ export interface Service {
     readonly name: string;
     readonly description: string;
     readonly phoneNumbers: ReadonlyArray<PhoneNumber>;
-    readonly physicalAddress: Address;
-    readonly postalAddress: Address;
+    readonly addresses: ReadonlyArray<Address>;
 }
 
 export interface TaskServices {
@@ -52,8 +47,16 @@ export interface ValidatedPhoneNumberJSON {
 }
 
 export interface ValidatedAddressJSON {
+    readonly address: string;
+    readonly city: string;
+    readonly state_province: string;
+    readonly postal_code: string;
+    readonly country: string;
+}
+
+export interface ValidatedAddressWithTypeJSON {
     readonly address_type: string;
-    readonly address: Address;
+    readonly address: ValidatedAddressJSON;
 }
 
 export interface ValidatedServiceJSON {
@@ -64,7 +67,7 @@ export interface ValidatedServiceJSON {
 
 export interface ValidatedLocationJSON {
     readonly phone_numbers: ReadonlyArray<ValidatedPhoneNumberJSON>;
-    readonly addresses: ReadonlyArray<ValidatedAddressJSON>;
+    readonly addresses: ReadonlyArray<ValidatedAddressWithTypeJSON>;
 }
 
 export interface ValidatedServiceAtLocationJSON {

--- a/src/stores/services/types.ts
+++ b/src/stores/services/types.ts
@@ -9,7 +9,7 @@ export interface Address {
     readonly type: string;
     readonly address: string;
     readonly city: string;
-    readonly province: string;
+    readonly stateProvince: string;
     readonly postalCode: string;
     readonly country: string;
 }


### PR DESCRIPTION
This is some clean up around the address piece for task services. The goal here was to keep consistent with our already established pattern which maybe wasn't as obvious as it could be so I'm putting it here:

`request JSON from server -> validate JSON (throw if invalid) -> convert TS type representing valid JSON to TS type representing valid store object`

In this particular scenario each address from the server comes in the form: `{address_type: string, address: object}` once validated our TS type: `ValidatedAddressWithTypeJSON` is then converted to its store representation: `Address` which has its type field embedded.