### PR TITLE
Feature/issue 327 google maps

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,7 +6,12 @@
     "version": "1.0.0",
     "slug": "arrival_advisor",
     "ios": {
-      "bundleIdentifier": "org.peacegeeks.arrivalAdvisor"
+      "bundleIdentifier": "org.peacegeeks.arrivalAdvisor",
+      "infoPlist": {
+        "LSApplicationQueriesSchemes": [
+          "comgooglemaps"
+        ]
+      }
     },
     "android": {
       "package": "org.peacegeeks.arrivalAdvisor"

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "react-native": "https://github.com/expo/react-native/archive/sdk-28.0.0.tar.gz",
     "react-native-collapsible": "0.12.0",
     "react-native-dotenv": "^0.2.0",
+    "react-native-map-link": "^2.1.4",
     "react-native-markdown-renderer": "^3.2.8",
     "react-redux": "^5.0.7",
     "react-router-native": "^4.3.0",

--- a/src/components/maps_application_popup/maps_application_popup_component.tsx
+++ b/src/components/maps_application_popup/maps_application_popup_component.tsx
@@ -1,7 +1,7 @@
 // tslint:disable no-class no-this no-expression-statement
 import React from 'react';
 import { View, Text, Icon, Button } from 'native-base';
-import { Popup } from 'react-native-map-link';
+import { showLocation } from 'react-native-map-link';
 import { Trans } from '@lingui/react';
 import { textStyles, colors, values, applicationStyles } from '../../application/styles';
 
@@ -11,59 +11,30 @@ interface MapsApplicationPopupProps {
     readonly locationTitle?: string;
 }
 
-interface State {
-    readonly isVisible: boolean;
-}
-
-export class MapsApplicationPopupComponent extends React.Component<MapsApplicationPopupProps, State> {
-    constructor(props: MapsApplicationPopupProps) {
-        super(props);
-        this.state = {
-            isVisible: false,
-        };
-        this.open = this.open.bind(this);
-        this.close = this.close.bind(this);
-    }
-
-    render(): JSX.Element {
-        return (
-            <View>
-                <Popup
-                    isVisible={this.state.isVisible}
-                    onCancelPressed={this.close}
-                    onAppPressed={this.close}
-                    onBackButtonPressed={this.close}
-                    modalProps={{
-                        animationIn: 'slideInUp',
-                        onBackdropPress: this.close,
-                    }}
-                    appsWhiteList={['apple-maps', 'google-maps']}
-                    options={{
-                        title: this.props.locationTitle,
-                        latitude: this.props.latitude,
-                        longitude: this.props.longitude,
+export const MapsApplicationPopupComponent: React.StatelessComponent<MapsApplicationPopupProps> =
+    (props: MapsApplicationPopupProps): JSX.Element => (
+        <View>
+            <Button
+                onPress={(): Promise<void> =>
+                    showLocation({
+                        title: props.locationTitle,
+                        latitude: props.latitude,
+                        longitude: props.longitude,
+                        appsWhiteList: ['apple-maps', 'google-maps'],
+                    }).catch((): void => alert('Supported applications include Apple or Google maps.'))
+                }
+                iconLeft
+                style={applicationStyles.orangeButton}
+            >
+                <Icon
+                    type={'FontAwesome'}
+                    name={'map-marker'}
+                    style={{
+                        color: colors.white,
+                        fontSize: values.smallIconSize,
                     }}
                 />
-                <Button onPress={this.open} iconLeft style={applicationStyles.orangeButton}>
-                    <Icon
-                        type={'FontAwesome'}
-                        name={'map-marker'}
-                        style={{
-                            color: colors.white,
-                            fontSize: values.smallIconSize,
-                        }}
-                    />
-                    <Text style={textStyles.button}><Trans>Open in map</Trans></Text>
-                </Button>
-            </View>
-        );
-    }
-
-    open(): void {
-        this.setState({ isVisible: true });
-    }
-
-    close(): void {
-        this.setState({ isVisible: false });
-    }
-}
+                <Text style={textStyles.button}><Trans>Open in map</Trans></Text>
+            </Button>
+        </View>
+    );

--- a/src/components/maps_application_popup/maps_application_popup_component.tsx
+++ b/src/components/maps_application_popup/maps_application_popup_component.tsx
@@ -1,0 +1,69 @@
+// tslint:disable no-class no-this no-expression-statement
+import React from 'react';
+import { View, Text, Icon, Button } from 'native-base';
+import { Popup } from 'react-native-map-link';
+import { Trans } from '@lingui/react';
+import { textStyles, colors, values, applicationStyles } from '../../application/styles';
+
+interface MapsApplicationPopupProps {
+    readonly latitude: number;
+    readonly longitude: number;
+    readonly locationTitle?: string;
+}
+
+interface State {
+    readonly isVisible: boolean;
+}
+
+export class MapsApplicationPopupComponent extends React.Component<MapsApplicationPopupProps, State> {
+    constructor(props: MapsApplicationPopupProps) {
+        super(props);
+        this.state = {
+            isVisible: false,
+        };
+        this.open = this.open.bind(this);
+        this.close = this.close.bind(this);
+    }
+
+    render(): JSX.Element {
+        return (
+            <View>
+                <Popup
+                    isVisible={this.state.isVisible}
+                    onCancelPressed={this.close}
+                    onAppPressed={this.close}
+                    onBackButtonPressed={this.close}
+                    modalProps={{
+                        animationIn: 'slideInUp',
+                        onBackdropPress: this.close,
+                    }}
+                    appsWhiteList={['apple-maps', 'google-maps']}
+                    options={{
+                        title: this.props.locationTitle,
+                        latitude: this.props.latitude,
+                        longitude: this.props.longitude,
+                    }}
+                />
+                <Button onPress={this.open} iconLeft style={applicationStyles.orangeButton}>
+                    <Icon
+                        type={'FontAwesome'}
+                        name={'map-marker'}
+                        style={{
+                            color: colors.white,
+                            fontSize: values.smallIconSize,
+                        }}
+                    />
+                    <Text style={textStyles.button}><Trans>Open in map</Trans></Text>
+                </Button>
+            </View>
+        );
+    }
+
+    open(): void {
+        this.setState({ isVisible: true });
+    }
+
+    close(): void {
+        this.setState({ isVisible: false });
+    }
+}

--- a/src/components/services/service_list_item_component.tsx
+++ b/src/components/services/service_list_item_component.tsx
@@ -8,20 +8,25 @@ import { TextWithPhoneLinks } from '../link/text_with_phone_links';
 import { mapWithIndex } from '../../application/map_with_index';
 import { ExpandableContentComponent } from '../expandable_content/expandable_content_component';
 import { Trans } from '@lingui/react';
+import { MapsApplicationPopupComponent } from '../maps_application_popup/maps_application_popup_component';
 
 interface ServiceListItemProps {
     readonly service: Service;
 }
 
 export const ServiceListItemComponent: React.StatelessComponent<ServiceListItemProps> =
-    (props: ServiceListItemProps): JSX.Element => (
-        <View style={{ backgroundColor: colors.white, padding: 10, borderRadius: values.lessRoundedBorderRadius }}>
-            {renderName(props.service.name)}
-            {renderDescription(props.service.description)}
-            {renderAddresses(filterPhysicalAddresses(props.service.addresses))}
-            {renderPhoneNumbers(props.service.phoneNumbers)}
-        </View>
-    );
+    (props: ServiceListItemProps): JSX.Element => {
+        const physicalAddresses = filterPhysicalAddresses(props.service.addresses);
+        return (
+            <View style={{ backgroundColor: colors.white, padding: 10, borderRadius: values.lessRoundedBorderRadius }}>
+                {renderName(props.service.name)}
+                {renderDescription(props.service.description)}
+                {renderAddresses(physicalAddresses)}
+                {renderPhoneNumbers(props.service.phoneNumbers)}
+                {renderMapButton(props.service.latitude, props.service.longitude, physicalAddresses)}
+            </View>
+        );
+    };
 
 const renderName = (name: string): JSX.Element => (
     <Text style={textStyles.headlineH3StyleBlackLeft}>{name}</Text>
@@ -53,6 +58,15 @@ const renderPhoneNumbers = (phoneNumbers: ReadonlyArray<PhoneNumber>) => (
         </Text>
     </View>), phoneNumbers))
 );
+
+const renderMapButton = (latitude: number, longitude: number, physicalAddresses: ReadonlyArray<Address>): JSX.Element => {
+    const locationTitle = physicalAddresses.length === 1 ? physicalAddresses[0].address : undefined;
+    return (
+        <View style={{ marginTop: 5 }}>
+            <MapsApplicationPopupComponent {...{ latitude, longitude, locationTitle}} />
+        </View>
+    );
+};
 
 const capitalizeFirstLetter = (s: string): string => (
     s.charAt(0).toUpperCase() + s.slice(1)

--- a/src/stores/__tests__/helpers/services_helpers.ts
+++ b/src/stores/__tests__/helpers/services_helpers.ts
@@ -72,6 +72,8 @@ export class AddressBuilder {
 
 export class ServiceBuilder {
     id: Id = aString();
+    latitude: number = aNumber();
+    longitude: number = aNumber();
     name: string = aString();
     description: string = aString();
     phoneNumbers: ReadonlyArray<PhoneNumber> = [];
@@ -102,9 +104,21 @@ export class ServiceBuilder {
         return this;
     }
 
+    withLatitude(latitude: number): ServiceBuilder {
+        this.latitude = latitude;
+        return this;
+    }
+
+    withLongitude(longitude: number): ServiceBuilder {
+        this.longitude = longitude;
+        return this;
+    }
+
     build(): Service {
         return {
             id: this.id,
+            latitude: this.latitude,
+            longitude: this.longitude,
             name: this.name,
             description: this.description,
             phoneNumbers: this.phoneNumbers,

--- a/src/stores/__tests__/helpers/services_schema_helpers.ts
+++ b/src/stores/__tests__/helpers/services_schema_helpers.ts
@@ -1,5 +1,5 @@
 // tslint:disable:no-class readonly-keyword no-expression-statement no-this no-let no-any
-import { aString, anInteger } from '../../../application/__tests__/helpers/random_test_values';
+import { aString, anInteger, aNumber } from '../../../application/__tests__/helpers/random_test_values';
 
 // The following "JSON" types exist purely to allow us to test our schemas with invalid data.
 // The optional and any properties on these types ensure we can create invalid objects.
@@ -30,6 +30,8 @@ interface ServiceJSON {
 }
 
 interface LocationJSON {
+    readonly latitude?: any;
+    readonly longitude?: any;
     readonly phone_numbers?: ReadonlyArray<PhoneNumberJSON>;
     readonly addresses?: ReadonlyArray<AddressWithTypeJSON>;
 }
@@ -267,8 +269,20 @@ export class ServiceJSONBuilder {
 }
 
 export class LocationJSONBuilder {
+    latitude: number | null = aNumber();
+    longitude: number | null = aNumber();
     phone_numbers: ReadonlyArray<PhoneNumberJSON> | null = [new PhoneNumberJSONBuilder().build()];
     addresses: ReadonlyArray<AddressWithTypeJSON> | null = [new AddressWithTypeJSONBuilder().build()];
+
+    withLatitude(latitude: number): LocationJSONBuilder {
+        this.latitude = latitude;
+        return this;
+    }
+
+    withLongitude(longitude: number): LocationJSONBuilder {
+        this.longitude = longitude;
+        return this;
+    }
 
     withPhoneNumbers(phoneNumbers: ReadonlyArray<PhoneNumberJSON> | null): LocationJSONBuilder {
         this.phone_numbers = phoneNumbers;
@@ -282,17 +296,43 @@ export class LocationJSONBuilder {
 
     build(): LocationJSON {
         return {
+            latitude: this.latitude,
+            longitude: this.longitude,
             phone_numbers: this.phone_numbers,
             addresses: this.addresses,
         };
     }
 
+    buildWithoutLatitude(): LocationJSON {
+        return {
+            longitude: this.longitude,
+            addresses: this.addresses,
+            phone_numbers: this.phone_numbers,
+        };
+    }
+
+    buildWithoutLongitude(): LocationJSON {
+        return {
+            latitude: this.latitude,
+            addresses: this.addresses,
+            phone_numbers: this.phone_numbers,
+        };
+    }
+
     buildWithoutPhoneNumbers(): LocationJSON {
-        return { addresses: this.addresses };
+        return {
+            latitude: this.latitude,
+            longitude: this.longitude,
+            addresses: this.addresses,
+        };
     }
 
     buildWithoutAddresses(): LocationJSON {
-        return { phone_numbers: this.phone_numbers };
+        return {
+            latitude: this.latitude,
+            longitude: this.longitude,
+            phone_numbers: this.phone_numbers,
+        };
     }
 }
 

--- a/src/stores/__tests__/helpers/services_schema_helpers.ts
+++ b/src/stores/__tests__/helpers/services_schema_helpers.ts
@@ -274,12 +274,12 @@ export class LocationJSONBuilder {
     phone_numbers: ReadonlyArray<PhoneNumberJSON> | null = [new PhoneNumberJSONBuilder().build()];
     addresses: ReadonlyArray<AddressWithTypeJSON> | null = [new AddressWithTypeJSONBuilder().build()];
 
-    withLatitude(latitude: number): LocationJSONBuilder {
+    withLatitude(latitude: number | null): LocationJSONBuilder {
         this.latitude = latitude;
         return this;
     }
 
-    withLongitude(longitude: number): LocationJSONBuilder {
+    withLongitude(longitude: number | null): LocationJSONBuilder {
         this.longitude = longitude;
         return this;
     }

--- a/src/stores/__tests__/services_schema.test.ts
+++ b/src/stores/__tests__/services_schema.test.ts
@@ -123,6 +123,50 @@ describe('schema for services_at_location endpoint', () => {
             });
         });
 
+        describe('latitude', () => {
+
+            test('location.latitude is required', () => {
+                const location = new helpers.LocationJSONBuilder().buildWithoutLatitude();
+                const validator = servicesAtLocationValidator([
+                    new helpers.ServiceAtLocationJSONBuilder().withLocation(location).build(),
+                ]);
+                expect(validator.isValid).toBe(false);
+                expect(validator.errors).toBe('data[0].location should have required property \'latitude\'');
+            });
+
+            test('location.latitude is of type number', () => {
+                const location = new helpers.LocationJSONBuilder().withLatitude(null).build();
+                const validator = servicesAtLocationValidator([
+                    new helpers.ServiceAtLocationJSONBuilder().withLocation(location).build(),
+                ]);
+                expect(validator.isValid).toBe(false);
+                expect(validator.errors).toBe('data[0].location.latitude should be number');
+            });
+
+        });
+
+        describe('longitude', () => {
+
+            test('location.longitude is required', () => {
+                const location = new helpers.LocationJSONBuilder().buildWithoutLongitude();
+                const validator = servicesAtLocationValidator([
+                    new helpers.ServiceAtLocationJSONBuilder().withLocation(location).build(),
+                ]);
+                expect(validator.isValid).toBe(false);
+                expect(validator.errors).toBe('data[0].location should have required property \'longitude\'');
+            });
+
+            test('location.longitude is of type number', () => {
+                const location = new helpers.LocationJSONBuilder().withLongitude(null).build();
+                const validator = servicesAtLocationValidator([
+                    new helpers.ServiceAtLocationJSONBuilder().withLocation(location).build(),
+                ]);
+                expect(validator.isValid).toBe(false);
+                expect(validator.errors).toBe('data[0].location.longitude should be number');
+            });
+
+        });
+
         describe('addresses', () => {
 
             test('location.addresses is required', () => {

--- a/src/stores/__tests__/services_schema.test.ts
+++ b/src/stores/__tests__/services_schema.test.ts
@@ -125,16 +125,15 @@ describe('schema for services_at_location endpoint', () => {
 
         describe('latitude', () => {
 
-            test('location.latitude is required', () => {
+            test('location.latitude is optional', () => {
                 const location = new helpers.LocationJSONBuilder().buildWithoutLatitude();
                 const validator = servicesAtLocationValidator([
                     new helpers.ServiceAtLocationJSONBuilder().withLocation(location).build(),
                 ]);
-                expect(validator.isValid).toBe(false);
-                expect(validator.errors).toBe('data[0].location should have required property \'latitude\'');
+                expect(validator.isValid).toBe(true);
             });
 
-            test('location.latitude is of type number', () => {
+            test('location.latitude, if provided, is of type number', () => {
                 const location = new helpers.LocationJSONBuilder().withLatitude(null).build();
                 const validator = servicesAtLocationValidator([
                     new helpers.ServiceAtLocationJSONBuilder().withLocation(location).build(),
@@ -147,16 +146,15 @@ describe('schema for services_at_location endpoint', () => {
 
         describe('longitude', () => {
 
-            test('location.longitude is required', () => {
+            test('location.longitude is optional', () => {
                 const location = new helpers.LocationJSONBuilder().buildWithoutLongitude();
                 const validator = servicesAtLocationValidator([
                     new helpers.ServiceAtLocationJSONBuilder().withLocation(location).build(),
                 ]);
-                expect(validator.isValid).toBe(false);
-                expect(validator.errors).toBe('data[0].location should have required property \'longitude\'');
+                expect(validator.isValid).toBe(true);
             });
 
-            test('location.longitude is of type number', () => {
+            test('location.longitude, if provided, is of type number', () => {
                 const location = new helpers.LocationJSONBuilder().withLongitude(null).build();
                 const validator = servicesAtLocationValidator([
                     new helpers.ServiceAtLocationJSONBuilder().withLocation(location).build(),

--- a/src/stores/services/index.ts
+++ b/src/stores/services/index.ts
@@ -28,6 +28,8 @@ export function serviceFromValidatedJSON(data: ValidatedServiceAtLocationJSON): 
 
     return {
         id: data.service.id,
+        latitude: data.location.longitude,
+        longitude: data.location.latitude,
         name: data.service.name,
         description: data.service.description,
         phoneNumbers: phoneNumbers,

--- a/src/stores/services/index.ts
+++ b/src/stores/services/index.ts
@@ -28,6 +28,7 @@ export function serviceFromValidatedJSON(data: ValidatedServiceAtLocationJSON): 
 
     return {
         id: data.service.id,
+        // These values come in the wrong order from the server
         latitude: data.location.longitude,
         longitude: data.location.latitude,
         name: data.service.name,

--- a/src/stores/services/schemas.ts
+++ b/src/stores/services/schemas.ts
@@ -77,10 +77,16 @@ const addressWithTypeArray = {
 const location = {
     "type": "object",
     "properties": {
+        "latitude": {
+            "type": "number"
+        },
+        "longitude": {
+            "type": "number"
+        },
         "phone_numbers": phoneNumberArray,
         "addresses": addressWithTypeArray
     },
-    "required": ["phone_numbers", "addresses"]
+    "required": ["latitude", "longitude", "phone_numbers", "addresses"]
 };
 
 export const serviceAtLocation = {

--- a/src/stores/services/schemas.ts
+++ b/src/stores/services/schemas.ts
@@ -86,7 +86,7 @@ const location = {
         "phone_numbers": phoneNumberArray,
         "addresses": addressWithTypeArray
     },
-    "required": ["latitude", "longitude", "phone_numbers", "addresses"]
+    "required": ["phone_numbers", "addresses"]
 };
 
 export const serviceAtLocation = {

--- a/src/stores/services/types.ts
+++ b/src/stores/services/types.ts
@@ -17,6 +17,8 @@ export interface Address {
 
 export interface Service {
     readonly id: Id;
+    readonly latitude: number;
+    readonly longitude: number;
     readonly name: string;
     readonly description: string;
     readonly phoneNumbers: ReadonlyArray<PhoneNumber>;
@@ -68,6 +70,8 @@ export interface ValidatedServiceJSON {
 }
 
 export interface ValidatedLocationJSON {
+    readonly latitude: number;
+    readonly longitude: number;
     readonly phone_numbers: ReadonlyArray<ValidatedPhoneNumberJSON>;
     readonly addresses: ReadonlyArray<ValidatedAddressWithTypeJSON>;
 }

--- a/src/stores/services/types.ts
+++ b/src/stores/services/types.ts
@@ -17,8 +17,8 @@ export interface Address {
 
 export interface Service {
     readonly id: Id;
-    readonly latitude: number;
-    readonly longitude: number;
+    readonly latitude?: number;
+    readonly longitude?: number;
     readonly name: string;
     readonly description: string;
     readonly phoneNumbers: ReadonlyArray<PhoneNumber>;
@@ -70,8 +70,8 @@ export interface ValidatedServiceJSON {
 }
 
 export interface ValidatedLocationJSON {
-    readonly latitude: number;
-    readonly longitude: number;
+    readonly latitude?: number;
+    readonly longitude?: number;
     readonly phone_numbers: ReadonlyArray<ValidatedPhoneNumberJSON>;
     readonly addresses: ReadonlyArray<ValidatedAddressWithTypeJSON>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6966,6 +6966,12 @@ react-is@^16.4.1:
   version "16.4.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.1.tgz#d624c4650d2c65dbd52c72622bbf389435d9776e"
 
+react-native-animatable@^1.2.4:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/react-native-animatable/-/react-native-animatable-1.3.0.tgz#b5c3940fc758cfd9b2fe54613a457c4b6962b46e"
+  dependencies:
+    prop-types "^15.5.10"
+
 react-native-branch@2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/react-native-branch/-/react-native-branch-2.2.5.tgz#4074dd63b4973e6397d9ce50e97b57c77a518e9d"
@@ -7020,6 +7026,13 @@ react-native-keyboard-aware-scroll-view@0.5.0:
     prop-types "^15.6.0"
     react-native-iphone-x-helper "^1.0.1"
 
+react-native-map-link@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/react-native-map-link/-/react-native-map-link-2.1.4.tgz#aaee570460cf4df5361f86b864f92c2397ad4d3f"
+  dependencies:
+    prop-types "^15.6.1"
+    react-native-modal "^6.4.0"
+
 react-native-maps@0.21.0:
   version "0.21.0"
   resolved "https://registry.yarnpkg.com/react-native-maps/-/react-native-maps-0.21.0.tgz#005f58e93d7623ad59667e8002101970ddf235c2"
@@ -7036,6 +7049,13 @@ react-native-markdown-renderer@^3.2.8:
     markdown-it "^8.4.0"
     prop-types "^15.5.10"
     react-native-fit-image "^1.5.2"
+
+react-native-modal@^6.4.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/react-native-modal/-/react-native-modal-6.5.0.tgz#46220b2289a41597d344c1db17454611b426a758"
+  dependencies:
+    prop-types "^15.6.1"
+    react-native-animatable "^1.2.4"
 
 react-native-reanimated@1.0.0-alpha.3:
   version "1.0.0-alpha.3"


### PR DESCRIPTION
Some notes:
- I've done a fair amount of testing to confirm physical addresses match lat/lng values coming from the server (they're two separate fields) from what I can tell this appears to be the case. This point is important as we currently are showing the physical location on services and want to make sure when pressing "Open in map" and navigating to the provided lat/lng we're navigating to the same location. No it does not look like we can just navigate to the address as a string.
- Some services do not provided lat/lng values for these no "Open in map" button is rendered.
- Once published we will need to recreate the IPA for iOS users in order for them to open the map using Google Maps as this is a change to `app.json`, Apple Maps should work fine