### PR TITLE
Issue #454 Show modal when final done question pressed, remove uneces…

### DIFF
--- a/src/components/questionnaire/new_topics_modal_component.tsx
+++ b/src/components/questionnaire/new_topics_modal_component.tsx
@@ -31,7 +31,7 @@ export interface NewTopicsModalActions {
 type Props = NewTopicsModalProps & NewTopicsModalActions;
 
 const logoSize = Dimensions.get('screen').width / 7;
-const maxListHeight = Dimensions.get('screen').height / 1.85;
+const maxListHeight = Dimensions.get('window').height / 1.85;
 
 export const NewTopicsModalComponent: React.StatelessComponent<Props> = (props: Props): JSX.Element => (
     <Modal isVisible={props.isVisible}>


### PR DESCRIPTION
…sary async calls, use 'window' instead of 'screen' to prevent modal cut off on Android devices

@rasmus-storjohann-PG can you test to see if this has improved the modal on your Android device?