### PR TITLE
Issue #471 Use overflow hidden instead of scroll for read more

### DIFF
--- a/src/components/expandable_content/expandable_content_component.tsx
+++ b/src/components/expandable_content/expandable_content_component.tsx
@@ -82,7 +82,7 @@ export class ExpandableContentComponent extends React.Component<ExpandableConten
     private getCollapsedStyle(): object {
         return {
             height: this.state.collapseAtHeight,
-            overflow: 'scroll',
+            overflow: 'hidden',
         };
     }
 


### PR DESCRIPTION
Android doesn't like "scroll", "hidden" works fine so we'll go with that.