### PR TITLE
Issue #448 Fix disclaimer links

### DIFF
--- a/src/components/disclaimer/disclaimer_component.tsx
+++ b/src/components/disclaimer/disclaimer_component.tsx
@@ -10,10 +10,10 @@ export const DisclaimerComponent: React.StatelessComponent = (): JSX.Element => 
     const welcomeBcUrl = 'https://www.welcomebc.ca';
     const bc211Url = 'https://www.bc211.ca';
     const welcomeBCLink = wrapWithSpace(
-        <Link href={welcomeBcUrl} text={'www.welcomebc.ca'} style={textStyles.paragraphURL} />,
+        <Link href={welcomeBcUrl} text={'www.welcomebc.ca, '} style={textStyles.paragraphURL} />,
     );
     const bc211Link = wrapWithSpace(
-        <Link href={bc211Url} text={'www.bc211.ca'} style={textStyles.paragraphURL} />,
+        <Link href={bc211Url} text={'www.bc211.ca.'} style={textStyles.paragraphURL} />,
     );
     return (
         <Content padder style={{ backgroundColor: colors.white }}>
@@ -23,8 +23,10 @@ export const DisclaimerComponent: React.StatelessComponent = (): JSX.Element => 
             <ParagraphComponent>
                 <Trans>
                     Arrival Advisor contains information from the BC Government’s Newcomer’s Guide, available at:
-                    {welcomeBCLink}, and the BC211 database of service providers, available at: {bc211Link}.
-            </Trans>
+                </Trans>
+                {welcomeBCLink}
+                <Trans>and the BC211 database of service providers, available at: </Trans>
+                {bc211Link}
             </ParagraphComponent>
             <ParagraphComponent>
                 <Trans>


### PR DESCRIPTION
These issues sneak by us because the links work when running the app through Expo but don’t when using a binary. The secret here is to make sure your link components are not rendered in `<Trans>` components (just as we do in the About component). I've confirmed this is fixed by building a binary only for use on the simulator which produces the following in Arabic:
![image](https://user-images.githubusercontent.com/3228323/55826724-7d5bd580-5abd-11e9-92bb-312ac9239c81.png)

So you see the links are fixed (open your app to see how they're currently broken) but will need translations.
