### PR TITLE
Issue #663 Remove additional padding from exapandable content component

### DIFF
--- a/src/components/expandable_content/expandable_content_component.tsx
+++ b/src/components/expandable_content/expandable_content_component.tsx
@@ -1,6 +1,6 @@
 // tslint:disable:no-class no-expression-statement no-this
 import React from 'react';
-import { Dimensions, LayoutChangeEvent, Animated, I18nManager, Platform } from 'react-native';
+import { Dimensions, LayoutChangeEvent, Animated, I18nManager } from 'react-native';
 import { View, Text, Button, Icon } from 'native-base';
 import { Trans } from '@lingui/react';
 import { colors, textStyles } from '../../application/styles';
@@ -80,14 +80,8 @@ export class ExpandableContentComponent extends React.Component<ExpandableConten
     }
 
     private getCollapsedStyle(): object {
-        const style = {
-            height: this.state.collapseAtHeight,
-        };
-        if (Platform.OS === 'ios') {
-            return style;
-        }
         return {
-            ...style,
+            height: this.state.collapseAtHeight,
             overflow: 'hidden',
         };
     }

--- a/src/components/expandable_content/expandable_content_component.tsx
+++ b/src/components/expandable_content/expandable_content_component.tsx
@@ -1,6 +1,6 @@
 // tslint:disable:no-class no-expression-statement no-this
 import React from 'react';
-import { Dimensions, LayoutChangeEvent, Animated, I18nManager } from 'react-native';
+import { Dimensions, LayoutChangeEvent, Animated, I18nManager, Platform } from 'react-native';
 import { View, Text, Button, Icon } from 'native-base';
 import { Trans } from '@lingui/react';
 import { colors, textStyles } from '../../application/styles';
@@ -72,19 +72,22 @@ export class ExpandableContentComponent extends React.Component<ExpandableConten
     }
 
     private renderContent(): JSX.Element {
-        const style = {
-            paddingHorizontal: 5,
-        };
         return (
-            <View style={this.isCollapsed() ? { ...this.getCollapsedStyle(), ...style } : style}>
+            <View style={this.isCollapsed() ? { ...this.getCollapsedStyle() } : {} }>
                 {this.props.content}
             </View>
         );
     }
 
     private getCollapsedStyle(): object {
-        return {
+        const style = {
             height: this.state.collapseAtHeight,
+        };
+        if (Platform.OS === 'ios') {
+            return style;
+        }
+        return {
+            ...style,
             overflow: 'hidden',
         };
     }


### PR DESCRIPTION
So I've removed some additional padding we were adding to this component and also the overflow settings for iOS which means the text won't look cut off. On Android we're going to have to live with the cut off text as this is actually a platform specific quirk.