### PR TITLE
Issue #703 Style markdown component

### DIFF
--- a/src/application/styles.ts
+++ b/src/application/styles.ts
@@ -309,6 +309,7 @@ export const markdownStyles = StyleSheet.create({
         fontFamily: 'AvenirBook',
         fontSize: 16,
         lineHeight: 21,
+        paddingHorizontal: values.backgroundTextPadding,
     },
     heading: {
         lineHeight: 26,

--- a/src/application/styles.ts
+++ b/src/application/styles.ts
@@ -305,12 +305,28 @@ export const applicationStyles = StyleSheet.create({
 export const markdownStyles = StyleSheet.create({
     text: {
         textAlign: 'left',
+        color: colors.greyishBrown,
+        fontFamily: 'AvenirBook',
+        fontSize: 16,
+        lineHeight: 21,
+    },
+    heading: {
+        lineHeight: 26,
+        marginTop: 10,
+        ...getBoldFontStylesForOS(),
+    },
+    heading1: {
+        fontSize: 22,
+      },
+    heading2: {
+        fontSize: 20,
     },
     listUnorderedItemIcon: {
         fontWeight: 'bold',
         fontSize: 35,
         marginLeft: 10,
         marginRight: 10,
+        color: colors.greyishBrown,
         ...Platform.select({
             ios: {
                 lineHeight: 36,
@@ -321,7 +337,7 @@ export const markdownStyles = StyleSheet.create({
         }),
     },
     link: {
-        color: 'blue',
+        color: colors.teal,
         textDecorationLine: 'underline',
     },
 });

--- a/src/application/styles.ts
+++ b/src/application/styles.ts
@@ -312,15 +312,20 @@ export const markdownStyles = StyleSheet.create({
         paddingHorizontal: values.backgroundTextPadding,
     },
     heading: {
-        lineHeight: 26,
         marginTop: 10,
         ...getBoldFontStylesForOS(),
     },
     heading1: {
-        fontSize: 22,
+        lineHeight: 23,
+        fontSize: 18,
       },
     heading2: {
-        fontSize: 20,
+        lineHeight: 22,
+        fontSize: 17,
+    },
+    heading3: {
+        lineHeight: 21,
+        fontSize: 16,
     },
     listUnorderedItemIcon: {
         fontWeight: 'bold',

--- a/src/components/expandable_content/expandable_content_component.tsx
+++ b/src/components/expandable_content/expandable_content_component.tsx
@@ -1,7 +1,7 @@
 // tslint:disable:no-class no-expression-statement no-this
 import React from 'react';
-import { Dimensions, LayoutChangeEvent, Animated, I18nManager } from 'react-native';
-import { View, Text, Button, Icon } from 'native-base';
+import { Dimensions, LayoutChangeEvent, Animated, I18nManager, TouchableOpacity, ViewStyle } from 'react-native';
+import { View, Text, Icon } from 'native-base';
 import { Trans } from '@lingui/react';
 import { colors, textStyles } from '../../application/styles';
 import { EmptyComponent } from '../empty_component/empty_component';
@@ -14,7 +14,6 @@ import { values } from '../../application/styles';
 export interface ExpandableContentProps {
     readonly content: JSX.Element;
     readonly contentId?: string;
-    readonly contentBackgroundColor?: string;
     readonly forceEnglish?: boolean;
 }
 
@@ -72,11 +71,9 @@ export class ExpandableContentComponent extends React.Component<ExpandableConten
     }
 
     private renderContent(): JSX.Element {
-        const style = {
-            paddingHorizontal: 5,
-        };
+        const style = this.isCollapsed() ? this.getCollapsedStyle() : {};
         return (
-            <View style={this.isCollapsed() ? { ...this.getCollapsedStyle(), ...style } : style}>
+            <View style={style}>
                 {this.props.content}
             </View>
         );
@@ -118,49 +115,56 @@ export class ExpandableContentComponent extends React.Component<ExpandableConten
         });
     }
 
-    private readMoreReadLessText(): JSX.Element {
+    private readMoreReadLessText(): JSX.Element | string {
         const showReadMore = this.isCollapsed();
         if (showReadMore) {
-            return this.props.forceEnglish ? <Text>Read more</Text> : <Trans>Read more</Trans>;
+            return this.props.forceEnglish ? 'Read more' : <Trans>Read more</Trans>;
         }
-        return this.props.forceEnglish ? <Text>Read less</Text> : <Trans>Read less</Trans>;
+        return this.props.forceEnglish ? 'Read less' : <Trans>Read less</Trans>;
     }
 
     private getReadMoreButton(): JSX.Element {
-        const onPress = (): void => this.toggleState();
-        const text = this.readMoreReadLessText();
-        const backgroundColor = this.backgroundColour();
-        const justifyContent = this.computeJustifyContent();
-
-        const textStyle: object = [
-            textStyles.paragraphBoldBlackLeft,
-            {
-                color: colors.teal,
-                paddingLeft: 6,
-                paddingRight: 8,
-            }];
-
-        const buttonText = <Text style={textStyle} >{text}</Text>;
-        const buttonIcon = <Icon
-            name={this.isCollapsed() ? 'arrow-down' : 'arrow-up'}
-            style={{ fontSize: values.smallIconSize, color: colors.teal }}
-        />;
-
-        const button = this.flipLeftRightOrientation() ?
-            <Button onPress={onPress} transparent iconLeft >
-                {buttonIcon}
-                {buttonText}
-            </Button> :
-            <Button onPress={onPress} transparent iconRight >
-                {buttonText}
-                {buttonIcon}
-            </Button>;
-
-        return (
-            <View style={{ backgroundColor, flex: 1, flexDirection: 'row', justifyContent }} >
-                {button}
-            </View>
+        const buttonOnPress = (): void => this.toggleState();
+        const buttonStyle: ViewStyle = {
+            flex: 1,
+            flexDirection: 'row',
+            justifyContent: this.computeJustifyContent(),
+            maxHeight: 20,
+            marginTop: 10,
+        };
+        const buttonText = (
+            <Text style={[
+                    textStyles.paragraphBoldBlackLeft,
+                    {
+                        color: colors.teal,
+                        marginRight: 5,
+                    },
+                ]}
+            >
+                    {this.readMoreReadLessText()}
+            </Text>
         );
+        const buttonIcon = (
+            <Icon
+                name={this.isCollapsed() ? 'arrow-down' : 'arrow-up'}
+                style={{
+                    fontSize: values.smallIconSize,
+                    color: colors.teal,
+                    paddingLeft: this.flipLeftRightOrientation() ? 10 : 0,
+                    paddingRight: this.flipLeftRightOrientation() ? 0 : 10,
+                }}
+            />
+        );
+
+        return this.flipLeftRightOrientation() ?
+            <TouchableOpacity onPress={buttonOnPress} style={buttonStyle}>
+                {buttonIcon}
+                {buttonText}
+            </TouchableOpacity> :
+            <TouchableOpacity onPress={buttonOnPress} style={buttonStyle}>
+                {buttonText}
+                {buttonIcon}
+            </TouchableOpacity>;
     }
 
     private flipLeftRightOrientation(): boolean {
@@ -174,10 +178,6 @@ export class ExpandableContentComponent extends React.Component<ExpandableConten
             return 'flex-end';
         }
         return 'flex-start';
-    }
-
-    private backgroundColour(): string {
-        return this.props.contentBackgroundColor || colors.white;
     }
 
     private isCollapsed(): boolean {

--- a/src/components/expandable_content/expandable_content_component.tsx
+++ b/src/components/expandable_content/expandable_content_component.tsx
@@ -150,12 +150,10 @@ export class ExpandableContentComponent extends React.Component<ExpandableConten
                 style={{
                     fontSize: values.smallIconSize,
                     color: colors.teal,
-                    paddingLeft: this.flipLeftRightOrientation() ? 10 : 0,
-                    paddingRight: this.flipLeftRightOrientation() ? 0 : 10,
+                    paddingHorizontal: 10,
                 }}
             />
         );
-
         return this.flipLeftRightOrientation() ?
             <TouchableOpacity onPress={buttonOnPress} style={buttonStyle}>
                 {buttonIcon}

--- a/src/components/explore/explore_detail_content_component.tsx
+++ b/src/components/explore/explore_detail_content_component.tsx
@@ -66,7 +66,6 @@ const CollapsibleIntroduction = (props: ExploreDetailContentProps): JSX.Element 
         content={<SelectableText style={textStyles.headlineH4StyleBlackLeft}>
         <Trans id={props.section.description} />
         </SelectableText>}
-        contentBackgroundColor={colors.lightGrey}
     />
 );
 

--- a/src/components/services/service_list_item_component.tsx
+++ b/src/components/services/service_list_item_component.tsx
@@ -44,10 +44,13 @@ const renderName = (name: string): JSX.Element => (
 );
 
 const renderDescription = (description: string): JSX.Element => {
-    return <ExpandableContentComponent
-        forceEnglish={true}
-        content={<Text style={textStyles.alwaysLeftParagraphStyle} > {description}</ Text>}
-    />;
+    const content = <Text style={textStyles.alwaysLeftParagraphStyle}> {description}</Text>;
+    return (
+        <ExpandableContentComponent
+            forceEnglish={true}
+            content={content}
+        />
+    );
 };
 
 const filterPhysicalAddresses = R.filter(R.propEq('type', 'physical_address'));
@@ -55,7 +58,7 @@ const filterPhysicalAddresses = R.filter(R.propEq('type', 'physical_address'));
 // tslint:disable-next-line:typedef
 const renderAddresses = (physicalAddresses: ReadonlyArray<Address>) => (
     mapWithIndex((address: Address, index: number) =>
-        <View key={index}>
+        <View key={index} style={{ marginTop: 10 }}>
             <Text style={[textStyles.paragraphBoldBlackLeft, textStyles.alwaysLeftAlign]}>Address:</Text>
             <Text style={textStyles.alwaysLeftParagraphStyle}>{address.address}</Text>
             <Text style={textStyles.alwaysLeftParagraphStyle}>
@@ -76,7 +79,7 @@ const renderPhoneNumbers = (phoneNumbers: ReadonlyArray<PhoneNumber>, currentPat
                 linkType={fieldLabel} />
         );
         return (
-            <View key={index} style={{ paddingVertical: 10 }} >
+            <View key={index} style={{ marginTop: 10 }} >
                 <Text style={[textStyles.paragraphBoldBlackLeft, textStyles.alwaysLeftAlign]}>
                     {fieldLabel} {textWithPhoneLinks}
                 </Text>
@@ -94,7 +97,7 @@ const renderWebsite = (website: string, currentPath: string, linkContext: string
     const link = <AnalyticsLink href={website} currentPath={currentPath} linkContext={linkContext}
         linkType={'Website'} style={textStyles.paragraphStyle}>{website}</AnalyticsLink>;
 
-    return <Text>{label}{link}</Text>;
+    return <Text style={{ marginTop: 10 }}>{label}{link}</Text>;
 };
 
 const renderEmail = (email: string, currentPath: string, linkContext: string): JSX.Element => {
@@ -106,7 +109,7 @@ const renderEmail = (email: string, currentPath: string, linkContext: string): J
     const link = <AnalyticsLink href={`mailto: ${email}`} currentPath={currentPath} linkContext={linkContext}
         linkType={'Email'} style={textStyles.paragraphStyle} >{email}</AnalyticsLink>;
 
-    return <Text>{label}{link}</Text>;
+    return <Text style={{ marginTop: 10 }}>{label}{link}</Text>;
 };
 
 const renderMapButtonIfLocation = (service: Service, currentPath: string, linkContext: string): JSX.Element => {

--- a/src/components/topics/task_detail_content_component.tsx
+++ b/src/components/topics/task_detail_content_component.tsx
@@ -106,12 +106,12 @@ const TitleComponent = (props: Props): JSX.Element => (
 );
 
 const markDownRules = {
-    link: (node: any, children: any) => {
+    link: (node: any, children: any): JSX.Element => {
         return (
             <Text key={node.key} style={markdownStyles.link} onPress={(): void => openUrl(node.attributes.href)}>
                 {children}
                 <Text>{' '}</Text>
-                <Icon name='external-link' type='FontAwesome' style={{ fontSize: 12, color: 'blue' }} />
+                <Icon name='external-link' type='FontAwesome' style={{ fontSize: 12, color: colors.teal }} />
             </Text>
         );
     },

--- a/src/components/topics/task_detail_content_component.tsx
+++ b/src/components/topics/task_detail_content_component.tsx
@@ -119,8 +119,21 @@ const markDownRules = {
 
 const TaskDescription = (props: Props): JSX.Element => {
     const topic = props.topic;
-    const taskDescription = <Markdown rules={markDownRules} style={markdownStyles}>{topic.description}</Markdown>;
-    return topic.relatedTopics.length > 0 ? <ExpandableContentComponent contentId={topic.id} content={taskDescription} /> : taskDescription;
+    const taskDescription = (
+        <Markdown
+            rules={markDownRules}
+            style={markdownStyles}
+        >
+            {topic.description}
+        </Markdown>
+    );
+    return topic.relatedTopics.length > 0 ?
+        <ExpandableContentComponent
+            contentId={topic.id}
+            content={taskDescription}
+        />
+        :
+        taskDescription;
 };
 
 const ServicesButton = (props: Props): JSX.Element => (


### PR DESCRIPTION
Along with the styling outlined in #703 these changes will also address some unwanted padding for the "Read more" component, discussed here: https://github.com/pg-irc/pathways-frontend/issues/663. The issues with cut-off text have been thoroughly discussed and come down to platform specific problems that we don't intend on fixing at this moment.

It may be useful if @cherrielam took a look at this PR as I've had to somewhat improvise on the heading style (although it should seem reasonable).