### PR TITLE
Issue #698 missing explore category translations 

### DIFF
--- a/src/components/topics/task_detail_content_component.tsx
+++ b/src/components/topics/task_detail_content_component.tsx
@@ -73,7 +73,7 @@ const TaxonomyComponent = (props: Props): JSX.Element => (
         },
     ]}
     >
-        {props.topic.exploreSection.name.toUpperCase()}
+        <Trans id={props.topic.exploreSection.name} />
     </Text>
 );
 


### PR DESCRIPTION
Dynamic strings can be translated if they are wrapped with the `<Trans>` macro and added as the `id` prop. 

We have recently introduced a new workflow with our ui-strings where we no longer use the fixtures data to receive translated strings. All translated strings can be found in the in a minified js file - `locale/*/messages.js` which lingui uses to find translated strings. 

I had to remove the capitalization of this category string because I would need to add a version of each category translation in uppercased format IE: 

```
msgid SETTLING IN

msgstr S'INSTALLER
```

As well native-base `<Text>`component currently does not have a way to text-transform this into uppercase like react natives `<Text>` component does. 


