### PR TITLE
Issue #712 Fix uppercase button text on Android

### DIFF
--- a/src/components/maps_application_popup/maps_application_popup_component.tsx
+++ b/src/components/maps_application_popup/maps_application_popup_component.tsx
@@ -22,7 +22,7 @@ export const MapsApplicationPopupComponent: React.StatelessComponent<MapsApplica
             style={{ color: colors.white, fontSize: values.smallIconSize }}
         />;
 
-        const text = <Text style={textStyles.button}>Open in maps</Text>;
+        const text = <Text style={textStyles.button} uppercase={false}>Open in maps</Text>;
 
         const flipLeftRightDirection = I18nManager.isRTL;
 


### PR DESCRIPTION
This is a NativeBase thing that happens when you nest their Text component inside their Button component, and only on Android, easy fix though.