### PR TITLE
Issue#703 Remaining UI issues related to the markdown/font styling

### DIFF
--- a/src/application/styles.ts
+++ b/src/application/styles.ts
@@ -350,6 +350,7 @@ export const markdownStyles = StyleSheet.create({
         }),
     },
     link: {
+        fontFamily: 'AvenirBook',
         color: colors.teal,
         textDecorationLine: 'underline',
     },

--- a/src/components/expandable_content/expandable_content_component.tsx
+++ b/src/components/expandable_content/expandable_content_component.tsx
@@ -138,6 +138,7 @@ export class ExpandableContentComponent extends React.Component<ExpandableConten
                     {
                         color: colors.teal,
                         marginRight: 5,
+                        marginLeft: 5
                     },
                 ]}
             >

--- a/src/components/topics/task_detail_content_component.tsx
+++ b/src/components/topics/task_detail_content_component.tsx
@@ -66,7 +66,8 @@ const TaxonomyComponent = (props: Props): JSX.Element => (
     <Text style={[
         textStyles.headlineH5StyleBlackLeft,
         {
-            paddingTop: 18,
+            marginTop: 20,
+            marginBottom: 5,
             paddingHorizontal: values.backgroundTextPadding,
         },
     ]}
@@ -86,7 +87,7 @@ const RecommendedComponent = (props: Props): JSX.Element => {
                     marginRight: 5,
                 }}
             />
-            <Text style={[textStyles.paragraphStyle, { color: colors.greyishBrown, fontSize: 14, fontFamily: 'AvenirBook'}]}>
+            <Text style={[textStyles.paragraphStyle, { color: colors.greyishBrown, fontSize: 14, fontFamily: 'AvenirBook' }]}>
                 <Trans>Recommended for you</Trans>
             </Text>
         </View>

--- a/src/components/topics/task_detail_content_component.tsx
+++ b/src/components/topics/task_detail_content_component.tsx
@@ -86,7 +86,7 @@ const RecommendedComponent = (props: Props): JSX.Element => {
                     marginRight: 5,
                 }}
             />
-            <Text style={[textStyles.paragraphStyle, { color: colors.greyishBrown, fontSize: 14, fontStyle: 'italic' }]}>
+            <Text style={[textStyles.paragraphStyle, { color: colors.greyishBrown, fontSize: 14, fontFamily: 'AvenirBook'}]}>
                 <Trans>Recommended for you</Trans>
             </Text>
         </View>

--- a/src/components/topics/task_detail_content_component.tsx
+++ b/src/components/topics/task_detail_content_component.tsx
@@ -66,9 +66,7 @@ const TaxonomyComponent = (props: Props): JSX.Element => (
     <Text style={[
         textStyles.headlineH5StyleBlackLeft,
         {
-            color: colors.greyishBrown,
-            marginTop: 20,
-            marginBottom: 5,
+            paddingTop: 18,
             paddingHorizontal: values.backgroundTextPadding,
         },
     ]}

--- a/src/components/topics/task_list_item_component.tsx
+++ b/src/components/topics/task_list_item_component.tsx
@@ -49,7 +49,7 @@ export const TaskListItemComponent: React.StatelessComponent<Props> = (props: Pr
                         <Text numberOfLines={2} style={textStyles.headlineH4StyleBlackLeft}>
                             {props.topic.title}
                         </Text>
-                        <Text note numberOfLines={1} style={{ textAlign: 'left' }}>
+                        <Text note numberOfLines={1} style={{ textAlign: 'left', fontFamily: 'AvenirBook' }}>
                             {taskDescription}
                         </Text>
                     </View>


### PR DESCRIPTION
There are 4 changes addressed in this PR:
- [ ] Links should be AvenirBook font to match rest of the content 
- [ ] Short description on recommended page should be AvenirBook font
- [ ] 'Recommended for you' on detailed task page should be AvenirBook font, won't be italicized anymore
- [ ] On detailed task page explore section style and related topic style should match
- [ ] 'Read more' on detailed task should be be aligned to the rest of the page (more padding now)