### PR TITLE
Issue #822 Fix start button for onboarding

### DIFF
--- a/src/components/swipeable_content/swipeable_content_component.tsx
+++ b/src/components/swipeable_content/swipeable_content_component.tsx
@@ -42,16 +42,13 @@ const buildState = (): [State, SetState] =>
 
 const buildPanResponder = (currentIndex: number, itemCount: number, setState: SetState): PanResponderInstance => (
     PanResponder.create({
-        onMoveShouldSetPanResponder,
+        onStartShouldSetPanResponder,
         onPanResponderEnd: onPanResponderEnd(currentIndex, itemCount, setState),
     })
 );
 
-const onMoveShouldSetPanResponder = (_event: GestureResponderEvent, gestureState: PanResponderGestureState): boolean => (
-    // For 3d touch devices (newer iPhones) we have problems with tappable items not being tappable when nested in the pan responder.
-    // See https://github.com/facebook/react-native/issues/3082 for more details.
-    // This basically says "your tap must be moving horizontally" in order for us to set the responder.
-    gestureState.dx !== 0
+const onStartShouldSetPanResponder = (_event: GestureResponderEvent, _gestureState: PanResponderGestureState): boolean => (
+    true
 );
 
 type OnPanResponderMoveCallback = (_event: GestureResponderEvent, _gestureState: PanResponderGestureState) => void;


### PR DESCRIPTION
Well, this was a slog as the documentation is pretty light on this topic. It turns out the fix is quite simple though and has to do with the fact that the onMove gesture responder is very sensitive and tends to highjack events bubbled from buttons so instead we use onStart. The button should work as expected now this has been tested (in Expo) on iPhone X (has 3d touch and works so we don't need our previous 3d touch "fix"), iPhone 8, Android 10, and Android 6.