### PR TITLE
QA-Tool Issue include services_at_location_id to human service data

### DIFF
--- a/src/validation/latlong/index.ts
+++ b/src/validation/latlong/index.ts
@@ -1,7 +1,7 @@
 // tslint:disable:no-var-requires
-const Ajv = require('ajv');
 import * as schema from './schema';
 import { LatLong } from './types';
+const Ajv = require('ajv');
 
 // tslint:disable-next-line:no-any
 export const toGeoCoderLatLong = (data: any): LatLong => {

--- a/src/validation/search/index.ts
+++ b/src/validation/search/index.ts
@@ -1,8 +1,8 @@
 // tslint:disable:no-var-requires no-any
-const Ajv = require('ajv');
 import { SearchServiceData } from './types';
 import { serviceSearchItemArray } from './schema';
 import { ValidationResult } from '../validation_result';
+const Ajv = require('ajv');
 
 export const validateServiceSearchResponse = (data: ReadonlyArray<any>): ValidationResult<SearchServiceData> => {
     const ajv = new Ajv();

--- a/src/validation/services/__tests__/helpers/services_schema_helpers.ts
+++ b/src/validation/services/__tests__/helpers/services_schema_helpers.ts
@@ -401,21 +401,21 @@ export class LocationJSONBuilder {
 }
 
 export class ServiceAtLocationJSONBuilder {
-    id: number | null = aNumber();
-    service: ServiceJSON | null = new ServiceJSONBuilder().build();
-    location: LocationJSON | null = new LocationJSONBuilder().build();
+    id: number = aNumber();
+    service: ServiceJSON = new ServiceJSONBuilder().build();
+    location: LocationJSON = new LocationJSONBuilder().build();
 
     withId(id: number): ServiceAtLocationJSONBuilder {
         this.id = id;
         return this;
     }
 
-    withService(service: ServiceJSON | null): ServiceAtLocationJSONBuilder {
+    withService(service: ServiceJSON): ServiceAtLocationJSONBuilder {
         this.service = service;
         return this;
     }
 
-    withLocation(location: LocationJSON | null): ServiceAtLocationJSONBuilder {
+    withLocation(location: LocationJSON): ServiceAtLocationJSONBuilder {
         this.location = location;
         return this;
     }

--- a/src/validation/services/__tests__/helpers/services_schema_helpers.ts
+++ b/src/validation/services/__tests__/helpers/services_schema_helpers.ts
@@ -40,6 +40,7 @@ interface LocationJSON {
 }
 
 interface ServiceAtLocationJSON {
+    readonly id?: number;
     readonly service?: ServiceJSON;
     readonly location?: LocationJSON;
 }
@@ -400,8 +401,14 @@ export class LocationJSONBuilder {
 }
 
 export class ServiceAtLocationJSONBuilder {
+    id: number | null = aNumber();
     service: ServiceJSON | null = new ServiceJSONBuilder().build();
     location: LocationJSON | null = new LocationJSONBuilder().build();
+
+    withId(id: number): ServiceAtLocationJSONBuilder {
+        this.id = id;
+        return this;
+    }
 
     withService(service: ServiceJSON | null): ServiceAtLocationJSONBuilder {
         this.service = service;
@@ -415,19 +422,29 @@ export class ServiceAtLocationJSONBuilder {
 
     build(): ServiceAtLocationJSON {
         return {
+            id: this.id,
             service: this.service,
             location: this.location,
         };
     }
 
+    buildWithoutId(): ServiceAtLocationJSON {
+        return {
+            location: this.location,
+            service: this.service,
+        };
+    }
+
     buildWithoutService(): ServiceAtLocationJSON {
         return {
+            id: this.id,
             location: this.location,
         };
     }
 
     buildWithoutLocation(): ServiceAtLocationJSON {
         return {
+            id: this.id,
             service: this.service,
         };
     }

--- a/src/validation/services/__tests__/services_schema.test.ts
+++ b/src/validation/services/__tests__/services_schema.test.ts
@@ -27,6 +27,16 @@ describe('schema for services_at_location endpoint', () => {
         });
     });
 
+    describe('validate service at location id', () => {
+        test('service at location is of type number', () => {
+            const validator = validateServicesAtLocationArray([
+                new helpers.ServiceAtLocationJSONBuilder().withId(null).build(),
+            ]);
+            expect(validator.isValid).toBe(false);
+            expect(validator.errors).toBe('data[0].id should be number');
+        });
+    });
+
     describe('validating service properties', () => {
 
         test('service is required', () => {

--- a/src/validation/services/__tests__/to_human_service_data.test.ts
+++ b/src/validation/services/__tests__/to_human_service_data.test.ts
@@ -6,6 +6,7 @@ describe('Adapting server service object to client service object', () => {
 
     it('it builds expected object', () => {
         const serverServiceObject = {
+            id: aNumber(),
             service: {
                 id: aString(),
                 name: aString(),
@@ -34,6 +35,7 @@ describe('Adapting server service object to client service object', () => {
         const clientServiceObject = serviceFromValidatedJSON(serverServiceObject);
         const expectedClientServiceObject = {
             id: serverServiceObject.service.id,
+            services_at_location_id: serverServiceObject.id,
             latlong: {
                 lat: serverServiceObject.location.latitude,
                 lng: serverServiceObject.location.longitude,

--- a/src/validation/services/index.ts
+++ b/src/validation/services/index.ts
@@ -1,9 +1,9 @@
 // tslint:disable:no-var-requires no-any
-const Ajv = require('ajv');
 import * as R from 'ramda';
 import * as types from './types';
 import { serviceAtLocationArray } from './schema';
 import { ValidationResult } from '../validation_result';
+const Ajv = require('ajv');
 
 export const validateServicesAtLocationArray = (data: ReadonlyArray<any>): ValidationResult<ValidatedServiceAtLocationJSON> => {
     const ajv = new Ajv();

--- a/src/validation/services/index.ts
+++ b/src/validation/services/index.ts
@@ -47,6 +47,7 @@ interface ValidatedLocationJSON {
 }
 
 export interface ValidatedServiceAtLocationJSON {
+    readonly id?: number;
     readonly service: ValidatedServiceJSON;
     readonly location: ValidatedLocationJSON;
 }
@@ -69,6 +70,7 @@ export const serviceFromValidatedJSON = (data: ValidatedServiceAtLocationJSON): 
 
     return {
         id: data.service.id,
+        services_at_location_id: data.id,
         latlong: {
             lat: data.location.latitude,
             lng: data.location.longitude,

--- a/src/validation/services/schema.ts
+++ b/src/validation/services/schema.ts
@@ -102,6 +102,9 @@ const location = {
 export const serviceAtLocation = {
     "type": "object",
     "properties": {
+        "id": {
+            "type": "number",
+        },
         "service": service,
         "location": location
     },

--- a/src/validation/services/types.ts
+++ b/src/validation/services/types.ts
@@ -21,6 +21,7 @@ export interface Address {
 
 export interface HumanServiceData {
     readonly id: Id;
+    readonly services_at_location_id?: number;
     readonly latlong?: LatLong;
     readonly name: string;
     readonly description: string;


### PR DESCRIPTION
`services_at_location_id` has been added as an optional property. The reason it has been made option and not required is because the current Algolia data does not provide the `service_at_location_id`.