### PR TITLE
Issue #861 Use last position to improve performance

### DIFF
--- a/src/async/location.ts
+++ b/src/async/location.ts
@@ -20,7 +20,7 @@ export const getDeviceLocation = async (manualUserLocation?: LatLong): DeviceLoc
         if (permissions.status !== 'granted') {
             return noLocationPermissionError();
         }
-        return await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Low, timeout: 5000 });
+        return await Location.getLastKnownPositionAsync();
     } catch (locationFetchTimeoutError) {
         return noLocationFetchTimeoutError();
     }


### PR DESCRIPTION
As per the documentation: "Consider using Location.getLastKnownPositionAsync if you expect to get a quick response and high accuracy is not required."  (https://docs.expo.io/versions/latest/sdk/location/#locationgetcurrentpositionasyncoptions). We were already setting the mode to low accuracy so I'm hoping this is sufficient and addresses the problems Jean outlines here: https://github.com/pg-irc/pathways-frontend/issues/861#issuecomment-575372732.

Testing instructions here: https://github.com/pg-irc/pathways-frontend/issues/861#issuecomment-583054283.

