### PR TITLE
Issue #1006 downgrade ts-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
         "redux-saga": "^1.1.3",
         "request": "^2.88.2",
         "sentry-expo": "~2.0.0",
-        "ts-node": "^8.6.2",
+        "ts-node": "8.5.4",
         "uuid": "^3.4.0"
     },
     "lingui": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7851,16 +7851,16 @@ ts-jest@^24.2.0:
     semver "^5.5"
     yargs-parser "10.x"
 
-ts-node@^8.6.2:
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.6.2.tgz#7419a01391a818fbafa6f826a33c1a13e9464e35"
-  integrity sha512-4mZEbofxGqLL2RImpe3zMJukvEvcO1XP8bj8ozBPySdCUXEcU5cIRwR0aM3R+VoZq7iXc8N86NC0FspGRqP4gg==
+ts-node@8.5.4:
+  version "8.5.4"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.5.4.tgz#a152add11fa19c221d0b48962c210cf467262ab2"
+  integrity sha512-izbVCRV68EasEPQ8MSIGBNK9dc/4sYJJKYA+IarMQct1RtEot6Xp0bXuClsbUSnKpg50ho+aOAx8en5c+y4OFw==
   dependencies:
     arg "^4.1.0"
     diff "^4.0.1"
     make-error "^1.1.1"
     source-map-support "^0.5.6"
-    yn "3.1.1"
+    yn "^3.0.0"
 
 ts-toolbelt@^6.1.11:
   version "6.1.13"
@@ -8519,7 +8519,7 @@ yargs@^9.0.0:
     y18n "^3.2.1"
     yargs-parser "^7.0.0"
 
-yn@3.1.1:
+yn@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
Upgrading ts-node 8.6.2 slows down compilation by a lot. 
https://github.com/TypeStrong/ts-node/issues/754