### PR TITLE
Issue #1017 Adjust notification time

### DIFF
--- a/src/components/bookmark_button/bookmark_button_component.tsx
+++ b/src/components/bookmark_button/bookmark_button_component.tsx
@@ -50,7 +50,7 @@ const getBookmarkButtonOnPress = (props: Props, i18n: I18n): ButtonOnPress => {
     const toastProps = {
         style: applicationStyles.toast,
         textStyle: textStyles.toast,
-        duration: 4000,
+        duration: 2000,
     };
     if (props.isBookmarked) {
         return (): void => {


### PR DESCRIPTION
So I tested this side by side on Android and iOS simulators and I think 2 seconds is a good amount of time for both platforms. However, I'm told that maybe on some physical Android devices the notification popup is too short. Please check and let me know!