### PR TITLE
Issue #1012 clicking load more services keeps scroll position

### DIFF
--- a/src/components/search/infinite_hits_component.tsx
+++ b/src/components/search/infinite_hits_component.tsx
@@ -82,33 +82,30 @@ export const InfiniteHitsComponent = (props: Partial<InfiniteHitsAndStateResults
         return renderErrorComponent(searchErrorProps);
     }
 
-    const renderLoadingScreen = (): JSX.Element => {
-        if (!isLoading(props.searching, props.isLatLongLoading)) {
-            return <EmptyComponent />;
-        }
-        return (
-            <View style={{ height: '100%', width: '100%' }}>
-                <LoadingServiceListComponent />
-            </View>
-        );
-    };
-
-    const ServiceList = (
-        <FlatList
-            style={{ backgroundColor: colors.white }}
-            refreshing={false}
-            data={searchResults}
-            keyExtractor={keyExtractor}
-            renderItem={renderSearchHit(props)}
-            ItemSeparatorComponent={SearchListSeparator}
-            ListHeaderComponent={renderHeader(showPartialLocalizationMessage, hidePartialLocalizationMessage)}
-            ListFooterComponent={loadMoreButton} />
-    );
-
     return (
         <View style={{ flexDirection: 'column', backgroundColor: colors.lightGrey, flex: 1 }}>
-            {renderLoadingScreen()}
-            {ServiceList}
+            {renderLoadingScreen(props.searching, props.isLatLongLoading)}
+            <FlatList
+                style={{ backgroundColor: colors.white }}
+                refreshing={false}
+                data={searchResults}
+                keyExtractor={keyExtractor}
+                renderItem={renderSearchHit(props)}
+                ItemSeparatorComponent={SearchListSeparator}
+                ListHeaderComponent={renderHeader(showPartialLocalizationMessage, hidePartialLocalizationMessage)}
+                ListFooterComponent={loadMoreButton}
+            />
+        </View>
+    );
+};
+
+const renderLoadingScreen = (searching: boolean, isLatLongLoading: boolean): JSX.Element => {
+    if (!isLoading(searching, isLatLongLoading)) {
+        return <EmptyComponent />;
+    }
+    return (
+        <View style={{ height: '100%', width: '100%' }}>
+            <LoadingServiceListComponent />
         </View>
     );
 };

--- a/src/components/search/infinite_hits_component.tsx
+++ b/src/components/search/infinite_hits_component.tsx
@@ -68,10 +68,6 @@ export const InfiniteHitsComponent = (props: Partial<InfiniteHitsAndStateResults
         return renderEmptyComponent(showPartialLocalizationMessage, hidePartialLocalizationMessage);
     }
 
-    if (isLoading(props.searching, props.isLatLongLoading)) {
-        return <LoadingServiceListComponent />;
-    }
-
     if (isSearchErrorType(onlineStatus, searchResults, latLong)) {
         const searchErrorProps = {
             onlineStatus,
@@ -83,6 +79,17 @@ export const InfiniteHitsComponent = (props: Partial<InfiniteHitsAndStateResults
         };
         return renderErrorComponent(searchErrorProps);
     }
+
+    const renderLoadingScreen = (): JSX.Element => {
+        if (!isLoading(props.searching, props.isLatLongLoading)) {
+            return <EmptyComponent />;
+        }
+        return (
+            <View style={{ height: '100%', width: '100%' }}>
+                <LoadingServiceListComponent />
+            </View>
+        );
+    };
 
     const ServiceList = (
         <FlatList
@@ -96,7 +103,12 @@ export const InfiniteHitsComponent = (props: Partial<InfiniteHitsAndStateResults
             ListFooterComponent={loadMoreButton} />
     );
 
-    return <View style={{ flexDirection: 'column', backgroundColor: colors.lightGrey, flex: 1 }}>{ServiceList}</View>;
+    return (
+        <View style={{ flexDirection: 'column', backgroundColor: colors.lightGrey, flex: 1 }}>
+            {renderLoadingScreen()}
+            {ServiceList}
+        </View>
+    );
 };
 
 const renderLoadMoreButton = (hasMore: boolean, refineNext: () => void): JSX.Element => {

--- a/src/components/search/infinite_hits_component.tsx
+++ b/src/components/search/infinite_hits_component.tsx
@@ -150,9 +150,12 @@ const isLoading = (searching: boolean, isLatLongLoading: boolean): boolean => (
 );
 
 const isSearchErrorType =
-(onlineStatus: OnlineStatus, searchResults: ReadonlyArray<SearchServiceData>, latLong: LatLong, searching: boolean): boolean => (
-    isOffline(onlineStatus) || hasNoResultsFromSearchTermQuery(searchResults) && !searching || hasNoResultsFromLocationQuery(latLong)
-);
+(onlineStatus: OnlineStatus, searchResults: ReadonlyArray<SearchServiceData>, latLong: LatLong, searching: boolean): boolean => {
+    if (searching) {
+        return false;
+    }
+    return isOffline(onlineStatus) || hasNoResultsFromSearchTermQuery(searchResults) || hasNoResultsFromLocationQuery(latLong);
+};
 
 const renderErrorComponent =
 (props: Partial<InfiniteHitsAndStateResultsProps>, onlineStatus: OnlineStatus, searchResults: ReadonlyArray<SearchServiceData>): JSX.Element => {


### PR DESCRIPTION
When Load more services was clicked, a complete re-render of the infiniteHitsComponent was triggered which would start the search service list from the top. In this PR, I overlaid the LoadingServiceList over top of the service list to prevent this from happening. 