### PR TITLE
Issue #1048 Services manual location

### DIFF
--- a/src/application/styles.ts
+++ b/src/application/styles.ts
@@ -345,12 +345,24 @@ export const applicationStyles = StyleSheet.create({
         flex: 1,
         height: 36,
     },
-    searchContainer: {
+    searchContainerExpanded: {
         backgroundColor: colors.white,
         borderRadius: values.lessRoundedBorderRadius,
         margin: 4,
         flexDirection: 'row',
         alignItems: 'center',
+        justifyContent: 'space-between',
+        paddingVertical: 1,
+    },
+    searchContainerCollapsed: {
+        backgroundColor: colors.white,
+        borderRadius: values.lessRoundedBorderRadius,
+        margin: 4,
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        overflow: 'hidden',
+        maxWidth: '100%',
     },
     boxShadowBelow: {
         shadowColor: colors.black,

--- a/src/application/styles.ts
+++ b/src/application/styles.ts
@@ -327,10 +327,10 @@ export const applicationStyles = StyleSheet.create({
     },
     searchButton: {
         borderRadius: values.roundedBorderRadius,
-        alignSelf: 'flex-start',
         flexDirection: 'row',
-        paddingHorizontal: 15,
-        paddingVertical: 4,
+        paddingHorizontal: 20,
+        paddingVertical: 9,
+        alignItems: 'center',
     },
     whiteTealButton: {
         backgroundColor: colors.white,

--- a/src/application/styles.ts
+++ b/src/application/styles.ts
@@ -39,6 +39,7 @@ export const values = {
     roundedBorderRadius: 25,
     lessRoundedBorderRadius: 10,
     backgroundTextPadding: 5,
+    disabledOpacity: .5,
 };
 
 const fontStyle = 'normal';

--- a/src/components/help/help_component.tsx
+++ b/src/components/help/help_component.tsx
@@ -13,7 +13,7 @@ import { MultiLineButtonComponent } from '../mutiline_button/multiline_button_co
 import { ReactI18nRenderProp, ReactI18n } from '../../locale/types';
 import * as R from 'ramda';
 import { SetManualUserLocationAction, ClearManualUserLocationAction } from '../../stores/manual_user_location';
-import { LatLong } from '../../validation/latlong/types';
+import { UserLocation } from '../../validation/latlong/types';
 
 const settlementWorkerTaskID = 'contact-workers-at-your-local-settlement-agency';
 
@@ -60,12 +60,12 @@ const fixture: ReadonlyArray<HelpContact> = [
 
 export interface HelpComponentProps {
     readonly history: History;
-    readonly manualUserLocation?: LatLong;
+    readonly manualUserLocation: UserLocation;
 }
 
 export interface HelpComponentActions {
     readonly clearAllUserState: () => ClearAllUserDataAction;
-    readonly setManualUserLocation: (userLocation: LatLong) => SetManualUserLocationAction;
+    readonly setManualUserLocation: (userLocation: UserLocation) => SetManualUserLocationAction;
     readonly clearManualUserLocation: () => ClearManualUserLocationAction;
 }
 

--- a/src/components/help/help_connected_component.tsx
+++ b/src/components/help/help_connected_component.tsx
@@ -11,7 +11,7 @@ import {
     setManualUserLocation,
 } from '../../stores/manual_user_location';
 import { selectManualUserLocation } from '../../selectors/services/select_manual_user_location';
-import { LatLong } from '../../validation/latlong/types';
+import { UserLocation } from '../../validation/latlong/types';
 
 const mapStateToProps = (store: Store, ownProps: RouterProps): HelpComponentProps => ({
     history: ownProps.history,
@@ -22,7 +22,7 @@ type Actions = ClearAllUserDataAction | SetManualUserLocationAction | ClearManua
 
 const mapDispatchToProps = (dispatch: Dispatch<Actions>): HelpComponentActions => ({
     clearAllUserState: (): ClearAllUserDataAction => dispatch(clearAllUserData()),
-    setManualUserLocation: (userLocation: LatLong): SetManualUserLocationAction => dispatch(setManualUserLocation(userLocation)),
+    setManualUserLocation: (userLocation: UserLocation): SetManualUserLocationAction => dispatch(setManualUserLocation(userLocation)),
     clearManualUserLocation: (): ClearManualUserLocationAction => dispatch(clearManualUserLocation()),
 });
 

--- a/src/components/help/manual_user_location.tsx
+++ b/src/components/help/manual_user_location.tsx
@@ -19,8 +19,8 @@ export class ManualUserLocation extends React.Component<Props, State> {
     constructor(props: Props) {
         super(props);
         this.state = {
-            latitude: props.manualUserLocation && '' + props.manualUserLocation.lat,
-            longitude: props.manualUserLocation && '' + props.manualUserLocation.lng,
+            latitude: props.manualUserLocation && '' + props.manualUserLocation.latLong.lat,
+            longitude: props.manualUserLocation && '' + props.manualUserLocation.latLong.lng,
         };
         this.onSetManualLocation = this.onSetManualLocation.bind(this);
         this.onClearManualLocation = this.onClearManualLocation.bind(this);
@@ -30,7 +30,10 @@ export class ManualUserLocation extends React.Component<Props, State> {
         const latitude = parseFloat(this.state.latitude);
         const longitude = parseFloat(this.state.longitude);
         if (latitude && longitude) {
-            this.props.setManualUserLocation({ lat: latitude, lng: longitude });
+            this.props.setManualUserLocation({
+                ...this.props.manualUserLocation,
+                latLong: { lat: latitude, lng: longitude },
+            });
         }
     }
 

--- a/src/components/search/api/fetch_lat_long_from_location.ts
+++ b/src/components/search/api/fetch_lat_long_from_location.ts
@@ -41,7 +41,7 @@ const fetchLatLongFromAddress = async (location: string): Promise<LatLong> => {
     }
 };
 
-const buildGeoCoderUrl = (location: string): string => (
+export const buildGeoCoderUrl = (location: string): string => (
     BuildUrl('https://geocoder.ca', {
         queryParams: {
             locate: location,
@@ -50,7 +50,7 @@ const buildGeoCoderUrl = (location: string): string => (
     })
 );
 
-const getTextIfValidOrThrow = (response: Response): Promise<string> => {
+export const getTextIfValidOrThrow = (response: Response): Promise<string> => {
     if (!response.ok) {
         throw new Error(`Invalid response ${JSON
             .stringify(response)}`);

--- a/src/components/search/clear_input_button.tsx
+++ b/src/components/search/clear_input_button.tsx
@@ -14,7 +14,7 @@ export const ClearInputButton = (props: Props): JSX.Element => {
         return <EmptyComponent />;
     }
     return (
-        <TouchableOpacity onPress={props.onPress} style={{ padding: 6 }}>
+        <TouchableOpacity onPress={props.onPress} style={{ padding: 10 }}>
             <Icon name={'window-close'} type='MaterialCommunityIcons' style={{ fontSize: values.smallIconSize, color: colors.black }} />
         </TouchableOpacity>
     );

--- a/src/components/search/search_input_component.tsx
+++ b/src/components/search/search_input_component.tsx
@@ -104,7 +104,7 @@ const CollapsedInput = (props: Props & CollapsedInputProps): JSX.Element => {
         <I18n>
             {(i18nRenderProp: ReactI18nRenderProp): JSX.Element => (
                 <View style={{ padding: 4, backgroundColor: colors.teal }}>
-                    <TouchableOpacity style={applicationStyles.searchContainer}
+                    <TouchableOpacity style={applicationStyles.searchContainerCollapsed}
                         onPress={(): void => props.setCollapseSearchInput(false)}>
                         <InputIcon name='search' />
                         <Text numberOfLines={1} style={[textStyles.paragraphStyle, { flex: 1 }]}>
@@ -153,7 +153,7 @@ const ExpandedInput = (props: Props & ExpandedInputProps): JSX.Element => {
 
                 <View style={{ padding: 4, backgroundColor: colors.teal }}>
 
-                    <TouchableOpacity style={applicationStyles.searchContainer}>
+                    <TouchableOpacity style={applicationStyles.searchContainerExpanded}>
                         <InputIcon name='search' />
                         <TextInput
                             ref={props.searchTermInputRef}
@@ -169,7 +169,7 @@ const ExpandedInput = (props: Props & ExpandedInputProps): JSX.Element => {
                         />
                         <ClearInputButton visible={props.searchTermInput !== ''} onPress={clearTermInput} />
                     </TouchableOpacity>
-                    <TouchableOpacity style={applicationStyles.searchContainer}>
+                    <TouchableOpacity style={applicationStyles.searchContainerExpanded}>
                         <InputIcon name='location-on' />
                         <TextInput
                             ref={props.searchLocationInputRef}
@@ -200,7 +200,7 @@ const ExpandedInput = (props: Props & ExpandedInputProps): JSX.Element => {
 const InputIcon = ({ name }: IconProps): JSX.Element => (
     <Icon name={name}
         type='MaterialIcons'
-        style={{ color: colors.teal, fontSize: values.mediumIconSize, padding: 5 }}
+        style={{ color: colors.teal, fontSize: values.smallIconSize, padding: 10 }}
     />
 );
 

--- a/src/components/search/search_input_component.tsx
+++ b/src/components/search/search_input_component.tsx
@@ -210,7 +210,7 @@ const renderSearchButton = (props: Props & ExpandedInputProps): JSX.Element => (
         onPress={(): void => {
             props.onSearchRequest(props.searchTermInput, props.searchLocationInput);
         }}>
-        <Text style={[textStyles.button, { fontSize: 16, padding: 5 }]}>
+        <Text style={[textStyles.button, { fontSize: 16 }]}>
             <Trans>
                 Search
             </Trans>

--- a/src/components/services/empty_service_list_component.tsx
+++ b/src/components/services/empty_service_list_component.tsx
@@ -9,12 +9,10 @@ export interface EmptyServiceListProps {
     readonly refreshScreen: () => void;
     readonly imageSource: ImageSourcePropType;
     readonly title: JSX.Element;
-    readonly header: JSX.Element;
 }
 
 export const EmptyServiceListComponent = (props: EmptyServiceListProps): JSX.Element => (
     <View style={{ flex: 1, backgroundColor: colors.lightGrey }}>
-        {props.header}
         <View
             style={{
                 flex: 1,

--- a/src/components/services/service_list_component.tsx
+++ b/src/components/services/service_list_component.tsx
@@ -47,16 +47,11 @@ export interface ServicesUpdater {
 
 type Props = ServiceListProps & ServiceListActions & ServicesUpdater & RouterProps;
 
-type Timestamp = number;
-type TimestampSetter = Dispatch<SetStateAction<Timestamp>>;
-
 export const ServiceListComponent = (props: Props): JSX.Element => {
-    const [lastScreenRefresh, setLastScreenRefresh]: readonly [Timestamp, TimestampSetter] = useState(Date.now());
-    useEffect(() => { refreshServices(props); }, [lastScreenRefresh, props.manualUserLocation]);
-    const refreshScreen = (): void => setLastScreenRefresh(Date.now());
+    useEffect(refreshServices(props), [props.manualUserLocation]);
 
     if (isSelectorErrorServicesForTopic(props.topicServicesOrError)) {
-        return renderErrorComponent(props, refreshScreen);
+        return renderErrorComponent(props, refreshServices(props));
     }
 
     if (isLoadingServices(props.topicServicesOrError) || isInitialEmptyTopicServices(props.topicServicesOrError)) {
@@ -64,7 +59,7 @@ export const ServiceListComponent = (props: Props): JSX.Element => {
     }
 
     if (isValidEmptyTopicServices(props.topicServicesOrError)) {
-        return renderEmptyComponent(props, refreshScreen);
+        return renderEmptyComponent(props, refreshServices(props));
     }
 
     return (
@@ -80,11 +75,13 @@ export const ServiceListComponent = (props: Props): JSX.Element => {
     );
 };
 
-const refreshServices = (props: Props): void => {
-    if (servicesFetchRequired(props.topicServicesOrError) || hasManualUserLocation(props.manualUserLocation)) {
-        props.dispatchServicesRequest();
+const refreshServices = (props: Props): () => void => (
+    (): void => {
+        if (servicesFetchRequired(props.topicServicesOrError) || hasManualUserLocation(props.manualUserLocation)) {
+            props.dispatchServicesRequest();
+        }
     }
-};
+);
 
 const servicesFetchRequired = (topicServicesOrError: SelectorTopicServices): boolean => (
     topicServicesOrError.type === constants.ERROR_SERVICES_FOR_TOPIC ||

--- a/src/components/services/service_list_component.tsx
+++ b/src/components/services/service_list_component.tsx
@@ -24,6 +24,7 @@ import { MessageComponent } from '../partial_localization/message_component';
 import { HidePartialLocalizationMessageAction } from '../../stores/user_profile';
 import { SetManualUserLocationAction } from '../../stores/manual_user_location';
 import { ServiceListLocationSearchComponent } from './service_list_location_search_component';
+import { SearchListSeparator } from '../search/separators';
 
 export interface ServiceListProps {
     readonly topic: Topic;
@@ -63,15 +64,21 @@ export const ServiceListComponent = (props: Props): JSX.Element => {
     }
 
     return (
-        <View>
-            {renderHeader(props)}
+        <ServiceListWrapper {...props}>
             <FlatList
-                style={{ backgroundColor: colors.lightGrey }}
+                style={{ backgroundColor: colors.white }}
                 data={getServicesIfValid(props.topicServicesOrError)}
                 keyExtractor={(service: HumanServiceData): string => service.id}
                 renderItem={renderServiceListItem(props)}
+                ItemSeparatorComponent={SearchListSeparator}
+                ListHeaderComponent={
+                    <MessageComponent
+                        isVisible={props.showPartialLocalizationMessage}
+                        hidePartialLocalizationMessage={props.hidePartialLocalizationMessage}
+                    />
+                }
             />
-        </View>
+        </ServiceListWrapper>
     );
 };
 
@@ -90,7 +97,16 @@ const servicesFetchRequired = (topicServicesOrError: SelectorTopicServices): boo
 );
 
 const hasManualUserLocation = (manualUserLocation: UserLocation): boolean => (
-    !!(manualUserLocation.label && manualUserLocation.latLong.lat && manualUserLocation.latLong.lng)
+    !!(manualUserLocation.label && manualUserLocation.latLong)
+);
+
+type ServiceListWrapperProps = Props & { readonly children: JSX.Element };
+
+const ServiceListWrapper = (props: ServiceListWrapperProps): JSX.Element => (
+    <View style={{ flex: 1 }}>
+        {renderHeader(props)}
+        {props.children}
+    </View>
 );
 
 const renderErrorComponent = (props: Props, refreshScreen: () => void): JSX.Element => {
@@ -98,41 +114,37 @@ const renderErrorComponent = (props: Props, refreshScreen: () => void): JSX.Elem
     const sentryMessage = getSentryMessageForError(errorType, constants.SENTRY_SERVICES_LISTING_ERROR_CONTEXT);
     Sentry.captureMessage(sentryMessage);
     return (
-        <ErrorScreenSwitcherComponent
-            refreshScreen={refreshScreen}
-            errorType={errorType}
-            header={renderHeader(props)}
-        />
+        <ServiceListWrapper {...props}>
+            <ErrorScreenSwitcherComponent
+                refreshScreen={refreshScreen}
+                errorType={errorType}
+            />
+        </ServiceListWrapper>
     );
 };
 
 const renderLoadingComponent = (props: Props): JSX.Element => (
-    <LoadingServiceListComponent
-        header={renderHeader(props)}
-    />
+    <ServiceListWrapper {...props}>
+        <LoadingServiceListComponent />
+    </ServiceListWrapper>
 );
 
 const renderEmptyComponent = (props: Props, refreshScreen: () => void): JSX.Element => (
-    <EmptyServiceListComponent
-        title={<Trans>No services to show</Trans>}
-        imageSource={emptyTopicServicesList}
-        refreshScreen={refreshScreen}
-        header={renderHeader(props)}
-    />
+    <ServiceListWrapper {...props}>
+        <EmptyServiceListComponent
+            title={<Trans>No services to show</Trans>}
+            imageSource={emptyTopicServicesList}
+            refreshScreen={refreshScreen}
+        />
+    </ServiceListWrapper>
 );
 
 const renderHeader = (props: Props): JSX.Element => (
-    <View>
-        <ServiceListHeaderComponent
-            title={props.topic.title}
-            manualUserLocation={props.manualUserLocation}
-            setManualUserLocation={props.setManualUserLocation}
-        />
-        <MessageComponent
-            isVisible={props.showPartialLocalizationMessage}
-            hidePartialLocalizationMessage={props.hidePartialLocalizationMessage}
-        />
-    </View>
+    <ServiceListHeaderComponent
+        title={props.topic.title}
+        manualUserLocation={props.manualUserLocation}
+        setManualUserLocation={props.setManualUserLocation}
+    />
 );
 
 const determineErrorType = (topicServicesOrError: SelectorTopicServices): Errors => {
@@ -181,9 +193,9 @@ export const ServiceListHeaderComponent = (props: ServiceListHeaderComponentProp
     <View
         style={{
             backgroundColor: colors.teal,
-            paddingTop: 25,
+            paddingTop: 10,
             paddingHorizontal: 10,
-            paddingBottom: 10,
+            paddingBottom: 4,
         }}
     >
         <Text style={[textStyles.headlineH2StyleWhiteLeft, { paddingHorizontal: 10}]}>

--- a/src/components/services/service_list_component.tsx
+++ b/src/components/services/service_list_component.tsx
@@ -84,20 +84,8 @@ export const ServiceListComponent = (props: Props): JSX.Element => {
 
 const refreshServices = (props: Props): () => void => (
     (): void => {
-        if (servicesFetchRequired(props.topicServicesOrError) || hasManualUserLocation(props.manualUserLocation)) {
-            props.dispatchServicesRequest();
-        }
+        props.dispatchServicesRequest();
     }
-);
-
-const servicesFetchRequired = (topicServicesOrError: SelectorTopicServices): boolean => (
-    topicServicesOrError.type === constants.ERROR_SERVICES_FOR_TOPIC ||
-    topicServicesOrError.type === constants.VALID_SERVICES_FOR_TOPIC && topicServicesOrError.isExpired ||
-    topicServicesOrError.type === constants.INITIAL_EMPTY_SERVICES_FOR_TOPIC
-);
-
-const hasManualUserLocation = (manualUserLocation: UserLocation): boolean => (
-    !!(manualUserLocation.label && manualUserLocation.latLong)
 );
 
 type ServiceListWrapperProps = Props & { readonly children: JSX.Element };

--- a/src/components/services/service_list_component.tsx
+++ b/src/components/services/service_list_component.tsx
@@ -14,7 +14,7 @@ import { isSelectorErrorServicesForTopic } from '../../selectors/services/is_sel
 import * as constants from '../../application/constants';
 import { ErrorScreenSwitcherComponent } from '../error_screens/ErrorScreenSwitcherComponent';
 import { Errors } from '../../validation/errors/types';
-import { LatLong } from '../../validation/latlong/types';
+import { UserLocation } from '../../validation/latlong/types';
 import { getSentryMessageForError } from '../../validation/errors/sentry_messages';
 import { Routes, RouterProps, goToRouteWithParameter } from '../../application/routing';
 import { LoadingServiceListComponent } from '../loading_screen/loading_service_list_component';
@@ -26,13 +26,13 @@ import { HidePartialLocalizationMessageAction } from '../../stores/user_profile'
 export interface ServiceListProps {
     readonly topic: Topic;
     readonly topicServicesOrError: SelectorTopicServices;
-    readonly manualUserLocation?: LatLong;
+    readonly manualUserLocation?: UserLocation;
     readonly bookmarkedServicesIds: ReadonlyArray<Id>;
     readonly showPartialLocalizationMessage: boolean;
 }
 
 export interface ServiceListActions {
-    readonly dispatchServicesRequest: (topic: Topic, manualUserLocation?: LatLong) => BuildServicesRequestAction;
+    readonly dispatchServicesRequest: (topic: Topic, manualUserLocation?: UserLocation) => BuildServicesRequestAction;
     readonly bookmarkService: (service: HumanServiceData) => BookmarkServiceAction;
     readonly unbookmarkService: (service: HumanServiceData) => UnbookmarkServiceAction;
     readonly hidePartialLocalizationMessage: () => HidePartialLocalizationMessageAction;

--- a/src/components/services/service_list_component.tsx
+++ b/src/components/services/service_list_component.tsx
@@ -1,5 +1,5 @@
 // tslint:disable:no-expression-statement
-import React, { useEffect, useState, Dispatch, SetStateAction } from 'react';
+import React, { useEffect } from 'react';
 import { ListRenderItemInfo, FlatList } from 'react-native';
 import { Trans } from '@lingui/react';
 import { View, Text } from 'native-base';

--- a/src/components/services/service_list_component.tsx
+++ b/src/components/services/service_list_component.tsx
@@ -186,7 +186,7 @@ export const ServiceListHeaderComponent = (props: ServiceListHeaderComponentProp
             paddingBottom: 4,
         }}
     >
-        <Text style={[textStyles.headlineH2StyleWhiteLeft, { paddingHorizontal: 10}]}>
+        <Text style={[textStyles.headlineH2StyleWhiteLeft, { paddingHorizontal: 10, marginBottom: 10 }]}>
             {props.title}
         </Text>
         <ServiceListLocationSearchComponent

--- a/src/components/services/service_list_connected_component.tsx
+++ b/src/components/services/service_list_connected_component.tsx
@@ -17,6 +17,7 @@ import { selectBookmarkedServicesIds } from '../../selectors/services/select_boo
 import { HumanServiceData } from '../../validation/services/types';
 import { selectShowPartialLocalizationMessage } from '../../selectors/user_profile/select_show_partial_localization_message';
 import { HidePartialLocalizationMessageAction, hidePartialLocalizationMessage } from '../../stores/user_profile';
+import { SetManualUserLocationAction, setManualUserLocation } from '../../stores/manual_user_location';
 
 const mapStateToProps = (store: Store, ownProps: RouterProps): ServiceListProps => {
     const topic: Topic = selectCurrentTopic(store, ownProps.match.params.topicId);
@@ -30,12 +31,13 @@ const mapStateToProps = (store: Store, ownProps: RouterProps): ServiceListProps 
     };
 };
 
-const mapDispatchToProps = (dispatch: Dispatch<ServicesAction>): ServiceListActions => ({
+const mapDispatchToProps = (dispatch: Dispatch<ServicesAction | SetManualUserLocationAction>): ServiceListActions => ({
     dispatchServicesRequest: (topic: Topic, manualUserLocation?: UserLocation): BuildServicesRequestAction =>
         dispatch(buildServicesRequest(topic.id, manualUserLocation)),
     bookmarkService: (service: HumanServiceData): BookmarkServiceAction => dispatch(bookmarkService(service)),
     unbookmarkService: (service: HumanServiceData): UnbookmarkServiceAction => dispatch(unbookmarkService(service)),
-    hidePartialLocalizationMessage: (): HidePartialLocalizationMessageAction => dispatch(hidePartialLocalizationMessage())
+    hidePartialLocalizationMessage: (): HidePartialLocalizationMessageAction => dispatch(hidePartialLocalizationMessage()),
+    setManualUserLocation: (userLocation: UserLocation): SetManualUserLocationAction => dispatch(setManualUserLocation(userLocation)),
 });
 
 type ComponentProps = ServiceListProps & ServiceListActions & ServicesUpdater;

--- a/src/components/services/service_list_connected_component.tsx
+++ b/src/components/services/service_list_connected_component.tsx
@@ -12,7 +12,7 @@ import {
 } from './service_list_component';
 import { RouterProps } from '../../application/routing';
 import { selectManualUserLocation } from '../../selectors/services/select_manual_user_location';
-import { LatLong } from '../../validation/latlong/types';
+import { UserLocation } from '../../validation/latlong/types';
 import { selectBookmarkedServicesIds } from '../../selectors/services/select_bookmarked_services_ids';
 import { HumanServiceData } from '../../validation/services/types';
 import { selectShowPartialLocalizationMessage } from '../../selectors/user_profile/select_show_partial_localization_message';
@@ -31,7 +31,7 @@ const mapStateToProps = (store: Store, ownProps: RouterProps): ServiceListProps 
 };
 
 const mapDispatchToProps = (dispatch: Dispatch<ServicesAction>): ServiceListActions => ({
-    dispatchServicesRequest: (topic: Topic, manualUserLocation?: LatLong): BuildServicesRequestAction =>
+    dispatchServicesRequest: (topic: Topic, manualUserLocation?: UserLocation): BuildServicesRequestAction =>
         dispatch(buildServicesRequest(topic.id, manualUserLocation)),
     bookmarkService: (service: HumanServiceData): BookmarkServiceAction => dispatch(bookmarkService(service)),
     unbookmarkService: (service: HumanServiceData): UnbookmarkServiceAction => dispatch(unbookmarkService(service)),

--- a/src/components/services/service_list_location_search_component.tsx
+++ b/src/components/services/service_list_location_search_component.tsx
@@ -7,7 +7,7 @@ import { I18n } from '@lingui/react';
 import { t } from '@lingui/macro';
 import { UserLocation, LatLong } from '../../validation/latlong/types';
 import { SetManualUserLocationAction } from '../../stores/manual_user_location';
-import { buildGeoCoderUrl, getTextIfValidOrThrow } from '../search/api/use_fetch_lat_long_from_location';
+import { buildGeoCoderUrl, getTextIfValidOrThrow } from '../search/api/fetch_lat_long_from_location';
 import { toGeoCoderLatLong } from '../../validation/latlong';
 import { applicationStyles, colors, textStyles, values } from '../../application/styles';
 import { MY_LOCATION } from '../../application/constants';

--- a/src/components/services/service_list_location_search_component.tsx
+++ b/src/components/services/service_list_location_search_component.tsx
@@ -28,6 +28,7 @@ export const ServiceListLocationSearchComponent = (props: Props): JSX.Element =>
         return (
             <CollapsedSearch
                 locationInputValue={locationInputValue}
+                setLocationInputValue={setLocationInputValue}
                 setSearchIsCollapsed={setSearchIsCollapsed}
             />
         );
@@ -40,6 +41,7 @@ export const ServiceListLocationSearchComponent = (props: Props): JSX.Element =>
             isFetchingLatLng={isFetchingLatLng}
             setIsFetchingLatLng={setIsFetchingLatLng}
             setManualUserLocation={props.setManualUserLocation}
+            manualUserLocation={props.manualUserLocation}
         />
     );
 };
@@ -47,13 +49,20 @@ export const ServiceListLocationSearchComponent = (props: Props): JSX.Element =>
 interface CollapsedSearchProps {
     readonly locationInputValue: string;
     readonly setSearchIsCollapsed: (b: boolean) => void;
+    readonly setLocationInputValue: (s: string) => void;
 }
 
 const CollapsedSearch = (props: CollapsedSearchProps): JSX.Element => {
-    const closeOnPress = (): void => props.setSearchIsCollapsed(false);
+    const closeOnPress = (): void => {
+        props.setSearchIsCollapsed(false);
+        props.setLocationInputValue('');
+    };
+    const wrapperOnPress = (): void => {
+        props.setSearchIsCollapsed(false);
+    };
     const translatedLocation = props.locationInputValue === MY_LOCATION ? <Trans>My Location</Trans> : props.locationInputValue;
     return (
-        <View style={[applicationStyles.searchContainer, { justifyContent: 'space-between', marginTop: 10 }]}>
+        <TouchableOpacity onPress={wrapperOnPress} style={[applicationStyles.searchContainer, { justifyContent: 'space-between', marginTop: 10 }]}>
             <View style={{ flexDirection: 'row', alignItems: 'center' }}>
                 <LocationIcon />
                 <Text style={[textStyles.paragraphStyle, { paddingVertical: 10 }]}>
@@ -63,7 +72,7 @@ const CollapsedSearch = (props: CollapsedSearchProps): JSX.Element => {
             <TouchableOpacity onPress={closeOnPress}>
                 <CloseIcon />
             </TouchableOpacity>
-        </View>
+        </TouchableOpacity>
     );
 };
 
@@ -73,6 +82,7 @@ interface ExpandedSearchProps {
     readonly isFetchingLatLng: boolean;
     readonly setIsFetchingLatLng: (b: boolean) => void;
     readonly setManualUserLocation: Props['setManualUserLocation'];
+    readonly manualUserLocation: Props['manualUserLocation'];
 }
 
 const ExpandedSearch = (props: ExpandedSearchProps): JSX.Element => {
@@ -82,6 +92,7 @@ const ExpandedSearch = (props: ExpandedSearchProps): JSX.Element => {
                 <SearchInput
                     locationInputValue={props.locationInputValue}
                     setLocationInputValue={props.setLocationInputValue}
+                    autoFocus={!!props.manualUserLocation.label}
                 />
             </View>
             <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', paddingHorizontal: 3 }}>
@@ -107,6 +118,7 @@ const ExpandedSearch = (props: ExpandedSearchProps): JSX.Element => {
 
 interface SearchInputProps {
     readonly locationInputValue: string;
+    readonly autoFocus: boolean;
     readonly setLocationInputValue: (s: string) => void;
 }
 
@@ -123,6 +135,7 @@ const SearchInput = (props: SearchInputProps): JSX.Element => (
                         placeholder={i18n._(t`Enter city, address, or postal code`)}
                         placeholderTextColor={colors.greyishBrown}
                         selectionColor={colors.black}
+                        autoFocus={props.autoFocus}
                     />
                 )
             }

--- a/src/components/services/service_list_location_search_component.tsx
+++ b/src/components/services/service_list_location_search_component.tsx
@@ -54,7 +54,7 @@ interface CollapsedSearchProps {
 }
 
 const CollapsedSearch = (props: CollapsedSearchProps): JSX.Element => {
-    const closeOnPress = (): void => {
+    const clearOnPress = (): void => {
         props.setSearchIsCollapsed(false);
         props.setLocationInputValue('');
     };
@@ -72,9 +72,7 @@ const CollapsedSearch = (props: CollapsedSearchProps): JSX.Element => {
                     <Text style={textStyles.paragraphBoldBlackLeft}>{locationText}</Text>
                 </Text>
             </View>
-            <TouchableOpacity onPress={closeOnPress}>
-                <CloseIcon />
-            </TouchableOpacity>
+            <ClearButton onPress={clearOnPress}/>
         </TouchableOpacity>
     );
 };
@@ -124,25 +122,38 @@ interface SearchInputProps {
     readonly setLocationInputValue: (s: string) => void;
 }
 
-const SearchInput = (props: SearchInputProps): JSX.Element => (
-    <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-        <LocationIcon />
-        <I18n>
-            {
-                (({ i18n }: { readonly i18n: I18n }): JSX.Element =>
-                    <TextInput
-                        style={applicationStyles.searchInput}
-                        onChangeText={props.setLocationInputValue}
-                        value={props.locationInputValue}
-                        placeholder={i18n._(t`Enter city, address, or postal code`)}
-                        placeholderTextColor={colors.greyishBrown}
-                        selectionColor={colors.black}
-                        autoFocus={props.autoFocus}
-                    />
-                )
-            }
-        </I18n>
-    </View>
+const SearchInput = (props: SearchInputProps): JSX.Element => {
+    const clearOnPress = (): void => {
+        props.setLocationInputValue('');
+    };
+    const ClearButtonOrEmpty = props.locationInputValue ? <ClearButton onPress={clearOnPress} /> : undefined;
+    return (
+        <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+            <LocationIcon />
+            <I18n>
+                {
+                    (({ i18n }: { readonly i18n: I18n }): JSX.Element =>
+                        <TextInput
+                            style={applicationStyles.searchInput}
+                            onChangeText={props.setLocationInputValue}
+                            value={props.locationInputValue}
+                            placeholder={i18n._(t`Enter city, address, or postal code`)}
+                            placeholderTextColor={colors.greyishBrown}
+                            selectionColor={colors.black}
+                            autoFocus={props.autoFocus}
+                        />
+                    )
+                }
+            </I18n>
+            {ClearButtonOrEmpty}
+        </View>
+    );
+};
+
+const ClearButton = (props: { readonly onPress: () => void }): JSX.Element => (
+    <TouchableOpacity onPress={props.onPress}>
+        <CloseIcon />
+    </TouchableOpacity>
 );
 
 const LocationIcon = (): JSX.Element => (

--- a/src/components/services/service_list_location_search_component.tsx
+++ b/src/components/services/service_list_location_search_component.tsx
@@ -1,0 +1,252 @@
+// tslint:disable:no-expression-statement
+import React, { useState } from 'react';
+import { View, Text, TextInput, TouchableOpacity } from 'react-native';
+import { Icon } from 'native-base';
+import { Trans } from '@lingui/react';
+import { I18n } from '@lingui/react';
+import { t } from '@lingui/macro';
+import { UserLocation, LatLong } from '../../validation/latlong/types';
+import { SetManualUserLocationAction } from '../../stores/manual_user_location';
+import { buildGeoCoderUrl, getTextIfValidOrThrow } from '../search/api/use_fetch_lat_long_from_location';
+import { toGeoCoderLatLong } from '../../validation/latlong';
+import { applicationStyles, colors, textStyles, values } from '../../application/styles';
+import { MY_LOCATION } from '../../application/constants';
+import { getDeviceLocation, DeviceLocation } from '../../async/location';
+import { isLocationFetchTimeoutError, isNoLocationPermissionError } from '../../validation/errors/is_error';
+
+interface Props {
+    readonly manualUserLocation: UserLocation;
+    readonly setManualUserLocation: (userLocation: UserLocation) => SetManualUserLocationAction;
+}
+
+export const ServiceListLocationSearchComponent = (props: Props): JSX.Element => {
+    const [locationInputValue, setLocationInputValue]: readonly [string, (s: string) => void] = useState(props.manualUserLocation.label);
+    const [isFetchingLatLng, setIsFetchingLatLng]: readonly [boolean, (b: boolean) => void] = useState<boolean>(false);
+    const [searchIsCollapsed, setSearchIsCollapsed]: readonly [boolean, (b: boolean) => void] = useState<boolean>(!!props.manualUserLocation.label);
+
+    if (searchIsCollapsed) {
+        return (
+            <CollapsedSearch
+                locationInputValue={locationInputValue}
+                setSearchIsCollapsed={setSearchIsCollapsed}
+            />
+        );
+    }
+
+    return (
+        <ExpandedSearch
+            locationInputValue={locationInputValue}
+            setLocationInputValue={setLocationInputValue}
+            isFetchingLatLng={isFetchingLatLng}
+            setIsFetchingLatLng={setIsFetchingLatLng}
+            setManualUserLocation={props.setManualUserLocation}
+        />
+    );
+};
+
+interface CollapsedSearchProps {
+    readonly locationInputValue: string;
+    readonly setSearchIsCollapsed: (b: boolean) => void;
+}
+
+const CollapsedSearch = (props: CollapsedSearchProps): JSX.Element => {
+    const closeOnPress = (): void => props.setSearchIsCollapsed(false);
+    const translatedLocation = props.locationInputValue === MY_LOCATION ? <Trans>My Location</Trans> : props.locationInputValue;
+    return (
+        <View style={[applicationStyles.searchContainer, { justifyContent: 'space-between', marginTop: 10 }]}>
+            <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+                <LocationIcon />
+                <Text style={[textStyles.paragraphStyle, { paddingVertical: 10 }]}>
+                    <Trans>Near</Trans> <Text style={textStyles.paragraphBoldBlackLeft}>{translatedLocation}</Text>
+                </Text>
+            </View>
+            <TouchableOpacity onPress={closeOnPress}>
+                <CloseIcon />
+            </TouchableOpacity>
+        </View>
+    );
+};
+
+interface ExpandedSearchProps {
+    readonly locationInputValue: string;
+    readonly setLocationInputValue: (s: string) => void;
+    readonly isFetchingLatLng: boolean;
+    readonly setIsFetchingLatLng: (b: boolean) => void;
+    readonly setManualUserLocation: Props['setManualUserLocation'];
+}
+
+const ExpandedSearch = (props: ExpandedSearchProps): JSX.Element => {
+    return (
+        <View>
+            <View style={[applicationStyles.searchContainer, { marginTop: 10 } ]}>
+                <SearchInput
+                    locationInputValue={props.locationInputValue}
+                    setLocationInputValue={props.setLocationInputValue}
+                />
+            </View>
+            <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', paddingHorizontal: 3 }}>
+                <LocateButton
+                    onPress={getLocateOnPress(
+                        props.setIsFetchingLatLng,
+                        props.setManualUserLocation,
+                    )}
+                    isFetchingLatLng={props.isFetchingLatLng}
+                />
+                <SearchButton
+                    onPress={getSearchOnPress(
+                        props.setIsFetchingLatLng,
+                        props.locationInputValue,
+                        props.setManualUserLocation,
+                    )}
+                    isFetchingLatLng={props.isFetchingLatLng}
+                />
+            </View>
+        </View>
+    );
+};
+
+interface SearchInputProps {
+    readonly locationInputValue: string;
+    readonly setLocationInputValue: (s: string) => void;
+}
+
+const SearchInput = (props: SearchInputProps): JSX.Element => (
+    <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+        <LocationIcon />
+        <I18n>
+            {
+                (({ i18n }: { readonly i18n: I18n }): JSX.Element =>
+                    <TextInput
+                        style={applicationStyles.searchInput}
+                        onChangeText={props.setLocationInputValue}
+                        value={props.locationInputValue}
+                        placeholder={i18n._(t`Enter city, address, or postal code`)}
+                        placeholderTextColor={colors.greyishBrown}
+                        selectionColor={colors.black}
+                    />
+                )
+            }
+        </I18n>
+    </View>
+);
+
+const LocationIcon = (): JSX.Element => (
+    <Icon
+        name={'location-on'}
+        type='MaterialIcons'
+        style={{ color: colors.teal, fontSize: values.smallIconSize, padding: 10 }}
+    />
+);
+
+const CloseIcon = (): JSX.Element => (
+    <Icon
+        name={'window-close'}
+        type='MaterialCommunityIcons'
+        style={{ color: colors.black, fontSize: values.smallIconSize, padding: 10 }}
+    />
+);
+
+interface SearchButtonProps {
+    readonly onPress: () => void;
+    readonly isFetchingLatLng: boolean;
+}
+
+const SearchButton = (props: SearchButtonProps): JSX.Element => (
+    <TouchableOpacity
+        style={[
+            applicationStyles.searchButton,
+            {
+                backgroundColor: colors.lightTeal,
+                opacity: props.isFetchingLatLng ? values.disabledOpacity : 1,
+            },
+        ]}
+        onPress={props.onPress}
+        disabled={props.isFetchingLatLng}
+    >
+        <Text style={[textStyles.button, { fontSize: 16 }]}>
+            <Trans>Search</Trans>
+        </Text>
+    </TouchableOpacity>
+);
+
+interface LocateButtonProps {
+    readonly onPress: () => void;
+    readonly isFetchingLatLng: boolean;
+}
+
+const LocateButton = (props: LocateButtonProps): JSX.Element => (
+    <TouchableOpacity
+        style={[
+            applicationStyles.searchButton,
+            {
+                backgroundColor: colors.white,
+                opacity: props.isFetchingLatLng ? values.disabledOpacity : 1,
+            },
+        ]}
+        onPress={props.onPress}
+        disabled={props.isFetchingLatLng}
+    >
+        <Icon
+            type={'MaterialIcons'} name={'my-location'}
+            style={{ color: colors.greyishBrown, fontSize: 16, marginRight: 5 }}
+        />
+        <Text style={[textStyles.button, { color: colors.greyishBrown, fontSize: 12 }]}>
+            <Trans>My Location</Trans>
+        </Text>
+    </TouchableOpacity>
+);
+
+const getSearchOnPress = (
+    setIsFetchingLatLng: (isFetchingLatLng: boolean) => void,
+    locationInputValue: string,
+    setManualUserLocation: Props['setManualUserLocation'],
+): () => Promise<void> => async (): Promise<void> => {
+    if (locationInputValue === MY_LOCATION) return;
+    setIsFetchingLatLng(true);
+    const latLong = await fetchLatLngFromServer(locationInputValue);
+    setIsFetchingLatLng(false);
+
+    if (!latLong) return;
+    setManualUserLocation({
+        label: locationInputValue,
+        latLong,
+    });
+};
+
+const getLocateOnPress = (
+    setIsFetchingLatLng: (isFetchingLatLng: boolean) => void,
+    setManualUserLocation: Props['setManualUserLocation'],
+): () => Promise<void> => async (): Promise<void> => {
+    setIsFetchingLatLng(true);
+    const latLong = await fetchLatLngFromDevice();
+    setIsFetchingLatLng(false);
+
+    if (!latLong) return;
+    setManualUserLocation({
+        label: MY_LOCATION,
+        latLong,
+    });
+};
+
+// TODO: These both may be handy elsewhere and could be moved into a helper file.
+const fetchLatLngFromServer = async (locationValue: string): Promise<LatLong | undefined> => (
+    fetch(buildGeoCoderUrl(locationValue))
+        .then(getTextIfValidOrThrow)
+        .then(JSON.parse)
+        .then(toGeoCoderLatLong)
+        .catch((error: string) => {
+            console.log(error);
+            return undefined;
+        })
+);
+
+const fetchLatLngFromDevice = async (): Promise<LatLong | undefined> => {
+    const deviceLocationResponse: DeviceLocation = await getDeviceLocation();
+    if (isNoLocationPermissionError(deviceLocationResponse) || isLocationFetchTimeoutError(deviceLocationResponse)) {
+        return undefined;
+    }
+    return {
+        lat: deviceLocationResponse.coords.latitude,
+        lng: deviceLocationResponse.coords.longitude,
+    };
+};

--- a/src/components/services/service_list_location_search_component.tsx
+++ b/src/components/services/service_list_location_search_component.tsx
@@ -13,6 +13,7 @@ import { applicationStyles, colors, textStyles, values } from '../../application
 import { MY_LOCATION } from '../../application/constants';
 import { getDeviceLocation, DeviceLocation } from '../../async/location';
 import { isLocationFetchTimeoutError, isNoLocationPermissionError } from '../../validation/errors/is_error';
+import { EmptyComponent } from '../empty_component/empty_component';
 
 interface Props {
     readonly manualUserLocation: UserLocation;
@@ -88,6 +89,14 @@ interface ExpandedSearchProps {
 }
 
 const ExpandedSearch = (props: ExpandedSearchProps): JSX.Element => {
+    const hasMyLocation = props.locationInputValue === MY_LOCATION;
+    const LocateButtonOrEmpty = !hasMyLocation ?
+        <LocateButton
+            onPress={getLocateOnPress(props.setLocationInputValue)}
+            isFetchingLatLng={props.isFetchingLatLng}
+        />
+        :
+        <EmptyComponent />;
     return (
         <View>
             <View style={[applicationStyles.searchContainerExpanded, { marginBottom: 4 }]}>
@@ -97,11 +106,16 @@ const ExpandedSearch = (props: ExpandedSearchProps): JSX.Element => {
                     autoFocus={!!props.manualUserLocation.label}
                 />
             </View>
-            <View style={[applicationStyles.searchContainerExpanded, { backgroundColor: colors.teal }]}>
-                <LocateButton
-                    onPress={getLocateOnPress(props.setLocationInputValue)}
-                    isFetchingLatLng={props.isFetchingLatLng}
-                />
+            <View
+                style={[
+                    applicationStyles.searchContainerExpanded,
+                    {
+                        backgroundColor: colors.teal,
+                        justifyContent: hasMyLocation ? 'flex-end' : 'space-between',
+                    },
+                ]}
+            >
+                {LocateButtonOrEmpty}
                 <SearchButton
                     onPress={getSearchOnPress(
                         props.setIsFetchingLatLng,
@@ -126,7 +140,10 @@ const SearchInput = (props: SearchInputProps): JSX.Element => {
     const clearOnPress = (): void => {
         props.setLocationInputValue('');
     };
-    const ClearButtonOrEmpty = props.locationInputValue ? <ClearButton onPress={clearOnPress} /> : undefined;
+    const ClearButtonOrEmpty = props.locationInputValue ?
+        <ClearButton onPress={clearOnPress} />
+        :
+        <EmptyComponent />;
     return (
         <View style={{ flexDirection: 'row', alignItems: 'center' }}>
             <LocationIcon />

--- a/src/components/services/service_list_location_search_component.tsx
+++ b/src/components/services/service_list_location_search_component.tsx
@@ -202,28 +202,39 @@ const getSearchOnPress = (
     setManualUserLocation: Props['setManualUserLocation'],
 ): () => Promise<void> => async (): Promise<void> => {
     if (locationInputValue === MY_LOCATION) return;
-    setIsFetchingLatLng(true);
-    const latLong = await fetchLatLngFromServer(locationInputValue);
-    setIsFetchingLatLng(false);
-
-    if (!latLong) return;
-    setManualUserLocation({
-        label: locationInputValue,
-        latLong,
-    });
+    const fetchFn = (): Promise<LatLong | undefined> => fetchLatLngFromServer(locationInputValue);
+    fetchLatLng(
+        setIsFetchingLatLng,
+        fetchFn,
+        setManualUserLocation,
+        locationInputValue,
+    );
 };
 
 const getLocateOnPress = (
     setIsFetchingLatLng: (isFetchingLatLng: boolean) => void,
     setManualUserLocation: Props['setManualUserLocation'],
 ): () => Promise<void> => async (): Promise<void> => {
-    setIsFetchingLatLng(true);
-    const latLong = await fetchLatLngFromDevice();
-    setIsFetchingLatLng(false);
+    fetchLatLng(
+        setIsFetchingLatLng,
+        fetchLatLngFromDevice,
+        setManualUserLocation,
+        MY_LOCATION,
+    );
+};
 
+const fetchLatLng = async (
+    setIsFetchingLatLng: (isFetchingLatLng: boolean) => void,
+    fetchFn: () => Promise<LatLong | undefined>,
+    setManualUserLocation: Props['setManualUserLocation'],
+    locationLabel: string,
+): Promise<void> => {
+    setIsFetchingLatLng(true);
+    const latLong = await fetchFn();
+    setIsFetchingLatLng(false);
     if (!latLong) return;
     setManualUserLocation({
-        label: MY_LOCATION,
+        label: locationLabel,
         latLong,
     });
 };

--- a/src/components/services/service_list_location_search_component.tsx
+++ b/src/components/services/service_list_location_search_component.tsx
@@ -200,7 +200,7 @@ const getSearchOnPress = (
     setIsFetchingLatLng: (isFetchingLatLng: boolean) => void,
     locationInputValue: string,
     setManualUserLocation: Props['setManualUserLocation'],
-): () => Promise<void> => async (): Promise<void> => {
+): () => void => (): void => {
     if (locationInputValue === MY_LOCATION) return;
     const fetchFn = (): Promise<LatLong | undefined> => fetchLatLngFromServer(locationInputValue);
     fetchLatLng(
@@ -214,7 +214,7 @@ const getSearchOnPress = (
 const getLocateOnPress = (
     setIsFetchingLatLng: (isFetchingLatLng: boolean) => void,
     setManualUserLocation: Props['setManualUserLocation'],
-): () => Promise<void> => async (): Promise<void> => {
+): () => void => (): void => {
     fetchLatLng(
         setIsFetchingLatLng,
         fetchLatLngFromDevice,
@@ -230,13 +230,18 @@ const fetchLatLng = async (
     locationLabel: string,
 ): Promise<void> => {
     setIsFetchingLatLng(true);
-    const latLong = await fetchFn();
+    const latLong = await fetchFn().catch(handleFetchError);
     setIsFetchingLatLng(false);
-    if (!latLong) return;
+    if (!latLong) return undefined;
     setManualUserLocation({
         label: locationLabel,
         latLong,
     });
+};
+
+const handleFetchError = (error: string): undefined => {
+    console.log(error);
+    return undefined;
 };
 
 // TODO: These both may be handy elsewhere and could be moved into a helper file.

--- a/src/sagas/services.ts
+++ b/src/sagas/services.ts
@@ -23,7 +23,7 @@ export function* updateServicesForTopic(action: actions.BuildServicesRequestActi
             return yield put(actions.buildServicesError(topicId, Errors.Offline));
         }
 
-        const deviceLocationResponse: DeviceLocation = yield call(getDeviceLocation, action.payload.manualUserLocation);
+        const deviceLocationResponse: DeviceLocation = yield call(getDeviceLocation, action.payload.manualUserLocation.latLong);
         if (errors.isNoLocationPermissionError(deviceLocationResponse)) {
             return yield put(actions.buildServicesError(topicId, deviceLocationResponse.type));
         }

--- a/src/selectors/services/select_manual_user_location.ts
+++ b/src/selectors/services/select_manual_user_location.ts
@@ -1,6 +1,6 @@
 import { Store } from '../../stores';
-import { LatLong } from '../../validation/latlong/types';
+import { UserLocation } from '../../validation/latlong/types';
 
-export const selectManualUserLocation = (store: Store): LatLong | undefined => (
+export const selectManualUserLocation = (store: Store): UserLocation => (
     store.manualUserLocation.userLocation
 );

--- a/src/selectors/services/to_selector_valid_services_for_topic.ts
+++ b/src/selectors/services/to_selector_valid_services_for_topic.ts
@@ -6,5 +6,4 @@ export const toSelectorValidServicesForTopic = (topicServices: ValidServicesForT
     SelectorValidServicesForTopic => ({
         services: topicServices.serviceIds.map((serviceId: ServiceId) => services[serviceId]),
         type: constants.VALID_SERVICES_FOR_TOPIC,
-        isExpired: topicServices.expiresAt < Date.now(),
     });

--- a/src/selectors/services/types.ts
+++ b/src/selectors/services/types.ts
@@ -4,7 +4,6 @@ import { Errors } from '../../validation/errors/types';
 export interface SelectorValidServicesForTopic {
     readonly services: ReadonlyArray<HumanServiceData>;
     readonly type: 'SERVICES_FOR_TOPIC:VALID';
-    readonly isExpired: boolean;
 }
 
 export interface SelectorLoadingServicesForTopic {

--- a/src/stores/__tests__/helpers/services_helpers.ts
+++ b/src/stores/__tests__/helpers/services_helpers.ts
@@ -191,7 +191,6 @@ export class ServicesForTopicBuilder {
     loading: boolean = false;
     message: string = aString();
     serviceIds: ReadonlyArray<Id> = [];
-    expiresAt: number = Date.now();
 
     withLoading(loading: boolean): ServicesForTopicBuilder {
         this.loading = loading;
@@ -200,11 +199,6 @@ export class ServicesForTopicBuilder {
 
     withServiceIds(serviceIds: ReadonlyArray<Id>): ServicesForTopicBuilder {
         this.serviceIds = serviceIds;
-        return this;
-    }
-
-    withExpiresAt(expiresAt: number): ServicesForTopicBuilder {
-        this.expiresAt = expiresAt;
         return this;
     }
 
@@ -217,7 +211,6 @@ export class ServicesForTopicBuilder {
         return {
             type: constants.VALID_SERVICES_FOR_TOPIC,
             serviceIds: this.serviceIds,
-            expiresAt: this.expiresAt,
         };
     }
 }

--- a/src/stores/__tests__/services.test.ts
+++ b/src/stores/__tests__/services.test.ts
@@ -140,39 +140,6 @@ describe('services reducer', () => {
             }
         });
 
-        it('sets service by topic expiration', () => {
-            if (isValidServicesForTopic(topicServicesOrErrorEntry)) {
-                expect(topicServicesOrErrorEntry.expiresAt).toBeDefined();
-            } else {
-                fail();
-            }
-        });
-
-        it('sets services by topic expiration to 24 hours from now', () => {
-            const expiresAt = Date.now();
-            const servicesForTopicBuilder = new ServicesForTopicBuilder().withExpiresAt(expiresAt);
-            const topicId = servicesForTopicBuilder.topicId;
-            const serviceBuilder = new ServiceBuilder().withId(topicId);
-            const storeBeforeAction = buildNormalizedServices([serviceBuilder], [servicesForTopicBuilder]);
-            const theAction: BuildServicesSuccessAction = {
-                type: constants.LOAD_SERVICES_SUCCESS,
-                payload: {
-                    topicId,
-                    services: [serviceBuilder.build()],
-                },
-            };
-            const storeAfterAction = reducer(storeBeforeAction, theAction);
-            const servicesByTopic = storeAfterAction.servicesByTopic[topicId];
-
-            if (isValidServicesForTopic(servicesByTopic)) {
-                const twentyFourHoursAfterExpiry = expiresAt + (24 * 60 * 60 * 1000);
-                const upperLimit = twentyFourHoursAfterExpiry + 5000;
-                expect(servicesByTopic.expiresAt).toBeGreaterThanOrEqual(twentyFourHoursAfterExpiry);
-                expect(servicesByTopic.expiresAt).toBeLessThan(upperLimit);
-            } else {
-                fail();
-            }
-        });
     });
 
     describe('when populating services for topic error object from an error response', () => {

--- a/src/stores/manual_user_location.ts
+++ b/src/stores/manual_user_location.ts
@@ -36,7 +36,7 @@ export const reducer = (store: ManualUserLocationStore = buildDefaultStore(), ac
         return { ...store, userLocation: action.payload.userLocation };
     }
     if (action.type === constants.CLEAR_MANUAL_USER_LOCATION) {
-        return { ...store, ...buildDefaultStore() };
+        return buildDefaultStore();
     }
     return store;
 };

--- a/src/stores/manual_user_location.ts
+++ b/src/stores/manual_user_location.ts
@@ -1,9 +1,9 @@
 import * as constants from '../application/constants';
 import * as helpers from './helpers/make_action';
-import { LatLong } from '../validation/latlong/types';
+import { UserLocation } from '../validation/latlong/types';
 
 // tslint:disable-next-line:typedef
-export const setManualUserLocation = (userLocation: LatLong) => (
+export const setManualUserLocation = (userLocation: UserLocation) => (
     helpers.makeAction(constants.SET_MANUAL_USER_LOCATION, { userLocation })
 );
 
@@ -16,12 +16,15 @@ export type SetManualUserLocationAction = Readonly<ReturnType<typeof setManualUs
 export type ClearManualUserLocationAction = Readonly<ReturnType<typeof clearManualUserLocation>>;
 
 export interface ManualUserLocationStore {
-    readonly userLocation?: LatLong;
+    readonly userLocation: UserLocation;
 }
 
-export const buildDefaultStore = (): ManualUserLocationStore => (
-    {}
-);
+export const buildDefaultStore = (): ManualUserLocationStore => ({
+    userLocation: {
+        label: '',
+        latLong: undefined,
+    },
+});
 
 type Actions = SetManualUserLocationAction | ClearManualUserLocationAction;
 
@@ -33,7 +36,7 @@ export const reducer = (store: ManualUserLocationStore = buildDefaultStore(), ac
         return { ...store, userLocation: action.payload.userLocation };
     }
     if (action.type === constants.CLEAR_MANUAL_USER_LOCATION) {
-        return { ...store, userLocation: undefined };
+        return { ...store, ...buildDefaultStore() };
     }
     return store;
 };

--- a/src/stores/services/actions.ts
+++ b/src/stores/services/actions.ts
@@ -3,7 +3,7 @@ import * as constants from '../../application/constants';
 import * as helpers from '../helpers/make_action';
 import { HumanServiceData } from '../../validation/services/types';
 import { Errors } from '../../validation/errors/types';
-import { LatLong } from '../../validation/latlong/types';
+import { UserLocation } from '../../validation/latlong/types';
 import { DataPersistence } from '../persisted_data';
 import { ClearAllUserDataAction } from '../questionnaire/actions';
 import { HidePartialLocalizationMessageAction } from '../user_profile';
@@ -33,7 +33,7 @@ export type ServicesAction =
     HidePartialLocalizationMessageAction;
 
 // tslint:disable-next-line:typedef
-export const buildServicesRequest = (topicId: TopicId, manualUserLocation?: LatLong) => (
+export const buildServicesRequest = (topicId: TopicId, manualUserLocation?: UserLocation) => (
     helpers.makeAction(constants.LOAD_SERVICES_REQUEST, { topicId, manualUserLocation })
 );
 

--- a/src/stores/services/index.ts
+++ b/src/stores/services/index.ts
@@ -59,8 +59,6 @@ const updateServicesSuccess = (store: types.ServiceStore, action: actions.BuildS
     const topicId = action.payload.topicId;
     const newServicesAsMap = createServiceMap(newServices);
     const newServiceIds = R.map((service: types.HumanServiceData): string => service.id, newServices);
-    const twentyFourHoursInMilliseconds = 24 * 60 * 60 * 1000;
-    const expiresAt = Date.now() + twentyFourHoursInMilliseconds;
     return {
         ...store,
         services: {
@@ -72,7 +70,6 @@ const updateServicesSuccess = (store: types.ServiceStore, action: actions.BuildS
             [topicId]: {
                 type: constants.VALID_SERVICES_FOR_TOPIC,
                 serviceIds: newServiceIds,
-                expiresAt,
             },
         },
     };

--- a/src/validation/latlong/types.ts
+++ b/src/validation/latlong/types.ts
@@ -2,3 +2,8 @@ export interface LatLong {
     readonly lat: number;
     readonly lng: number;
 }
+
+export interface UserLocation {
+    readonly label: string;
+    readonly latLong: LatLong;
+}

--- a/src/validation/services/types.ts
+++ b/src/validation/services/types.ts
@@ -36,7 +36,6 @@ export interface HumanServiceData {
 export interface ValidServicesForTopic {
     readonly type: 'SERVICES_FOR_TOPIC:VALID';
     readonly serviceIds: ReadonlyArray<Id>;
-    readonly expiresAt: number;
 }
 
 export interface LoadingServicesForTopic {


### PR DESCRIPTION
Please review these points:

- The new services location form sets the existing, but not in use, manual user location store value along with a new label property. This allows us to not have to  change the default behaviours of the services saga which will use the manual user location if it exists.
- Having a fixed header, outside the flatlist, now allows us to simplify our "refresh" logic, we don't need to set a timestamp in order to trigger the refresh
- If location lookup fails from the location form currently it does so silently and manual location is not updated, if this is not sufficient we could add lookup error message to the form 
- I've intentionally sparingly used outside code from the existing search files due to the large refactor that is currently being done for search.