### PR TITLE
Fix typo that causes submission modal to never appear

### DIFF
--- a/src/components/feedback/feedback_modal_container.tsx
+++ b/src/components/feedback/feedback_modal_container.tsx
@@ -32,7 +32,7 @@ export const FeedbackModalContainer = ({
         = useState<boolean>(query.optionsModalVisible === 'true');
 
     const [receiveUpdatesModalVisible, setReceiveUpdatesModalVisible]: readonly[boolean, Dispatch<SetStateAction<boolean>>]
-        = useState<boolean>(query.optionsModalVisible === 'true');
+        = useState<boolean>(query.receiveUpdatesModalVisible === 'true');
 
     const goToFeedbackOtherScreen = goToRouteWithParameters(
         Routes.Feedback,


### PR DESCRIPTION
The last commit for feedback screens introduced a bug that causes the final "follow this issue" modal to not pop up, see it here: https://github.com/pg-irc/pathways-frontend/commit/53c8944bd35e0040ce2c1921101c9cf9f5ec69f0#diff-d01f34bbf7fd0cdd2b0c252815a358a9R35. This PR corrects it.