### PR TITLE
Issue #1199 use former logic for showing different modal dialogs to e…

### DIFF
--- a/src/components/feedback/choose_mode_modal.tsx
+++ b/src/components/feedback/choose_mode_modal.tsx
@@ -9,6 +9,7 @@ import { CloseButtonComponent } from '../close_button_component';
 
 export interface FeedbackModalProps {
     readonly onClosePress: () => void;
+    readonly isVisible: boolean;
 }
 
 export interface ButtonsComponentProps {
@@ -21,7 +22,7 @@ type Props = FeedbackModalProps & ButtonsComponentProps;
 
 export const ChooseModeModal = (props: Props): JSX.Element => (
     <Modal
-        isVisible={true}
+        isVisible={props.isVisible}
         onBackdropPress={props.onClosePress}
         style={{ justifyContent: 'flex-end', margin: 0 }}
         backdropTransitionOutTiming={0}

--- a/src/components/feedback/modal_container.tsx
+++ b/src/components/feedback/modal_container.tsx
@@ -6,7 +6,6 @@ import { ChooseModeModal } from './choose_mode_modal';
 import { UserInformation } from '../../stores/feedback/types';
 import { DiscardChangesModal } from './discard_changes_modal';
 import { showToast } from '../../application/toast';
-import { EmptyComponent } from '../empty_component/empty_component';
 import { DiscardChangesAction, CancelDiscardChangesAction, CloseAction } from '../../stores/feedback';
 
 interface ModalContainerProps {
@@ -35,32 +34,28 @@ export const ModalContainer = (props: ModalContainerProps): JSX.Element => {
         props.discardFeedback();
     };
 
-    if (props.showChooseFeedbackModeModal) {
-        return <ChooseModeModal
-            onClosePress={props.close}
-            onChangeNameOrOtherDetailPress={props.chooseChangeNameOrDetail}
-            onChooseOtherChangesPress={props.chooseOtherChanges}
-            onChooseRemoveServicePress={props.chooseRemoveService}
-        />;
-    }
-
-    if (props.showReceiveUpdatesModal) {
-        return <ReceiveUpdatesModal
-            isSendingFeedback={props.isSendingFeedback}
-            setUserInformation={props.setUserInformation}
-            userInformation={props.userInformation}
-            onFinishPress={props.finishAndSendFeedback}
-            onModalHide={onReceiveUpdatesModalHide}
-        />;
-    }
-
-    if (props.showDiscardChangesModal) {
-        return <DiscardChangesModal
-            onDiscardPress={onDiscardModalDiscardPress}
-            onKeepEditingPress={props.cancelDiscardFeedback}
-            isVisible={true}
-        />;
-    }
-
-    return <EmptyComponent/>;
+    return (
+        <>
+            <ChooseModeModal
+                onClosePress={props.close}
+                onChangeNameOrOtherDetailPress={props.chooseChangeNameOrDetail}
+                onChooseOtherChangesPress={props.chooseOtherChanges}
+                onChooseRemoveServicePress={props.chooseRemoveService}
+                isVisible={props.showChooseFeedbackModeModal}
+            />
+            <ReceiveUpdatesModal
+                isSendingFeedback={props.isSendingFeedback}
+                setUserInformation={props.setUserInformation}
+                userInformation={props.userInformation}
+                onFinishPress={props.finishAndSendFeedback}
+                isVisible={props.showReceiveUpdatesModal}
+                onModalHide={onReceiveUpdatesModalHide}
+            />
+            <DiscardChangesModal
+                onDiscardPress={onDiscardModalDiscardPress}
+                onKeepEditingPress={props.cancelDiscardFeedback}
+                isVisible={props.showDiscardChangesModal}
+            />
+        </>
+    );
 };

--- a/src/components/feedback/receive_updates_modal.tsx
+++ b/src/components/feedback/receive_updates_modal.tsx
@@ -15,6 +15,7 @@ interface ReceiveUpdatesProps {
     readonly setUserInformation: Dispatch<SetStateAction<UserInformation>>;
     readonly userInformation: UserInformation;
     readonly onFinishPress: () => void;
+    readonly isVisible: boolean;
     readonly onModalHide: (i18n: I18n) => () => void;
 }
 
@@ -24,7 +25,7 @@ const ORGANIZATION_PLACEHOLDER = t`Enter your organization name`;
 const JOB_TITLE_PLACEHOLDER = t`Enter your job title`;
 
 export const ReceiveUpdatesModal =
-({ onFinishPress, isSendingFeedback, userInformation, setUserInformation, onModalHide }: ReceiveUpdatesProps): JSX.Element => {
+({ onFinishPress, isSendingFeedback, userInformation, setUserInformation, isVisible, onModalHide }: ReceiveUpdatesProps): JSX.Element => {
 
     const onPressIsEmployee = (): void =>
         setUserInformation({
@@ -38,7 +39,7 @@ export const ReceiveUpdatesModal =
     return (
         <I18n>
             {({ i18n }: I18nProps): JSX.Element => (
-                <Modal isVisible={true} backdropTransitionOutTiming={0} onModalHide={onModalHide(i18n)}>
+                <Modal isVisible={isVisible} backdropTransitionOutTiming={0} onModalHide={onModalHide(i18n)}>
                     <View style={[styles.receiveUpdatesContainer, { minHeight }]}>
                         <View style={styles.receiveUpdatesInnerContainer}>
                             <View>


### PR DESCRIPTION
In this PR I had to revert the using the former way of showing different modal dialogs since `onModalHide` will not trigger if `isVisible` is always set to true.