### PR TITLE
Feature/issue 1142 use expo android status bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
         "expo-intent-launcher": "~8.2.1",
         "expo-location": "~8.2.1",
         "expo-notifications": "~0.3.3",
+        "expo-status-bar": "^1.0.0",
         "history": "^4.10.1",
         "intl": "^1.2.5",
         "native-base": "^2.13.12",

--- a/src/application/index.tsx
+++ b/src/application/index.tsx
@@ -9,8 +9,6 @@ import { buildSaga } from '../sagas';
 import { API_URL } from 'react-native-dotenv';
 import { setUrl } from '../api';
 import {YellowBox} from 'react-native';
-import { setStatusBarBackgroundColor, setStatusBarStyle } from 'expo-status-bar';
-import { isAndroid } from './helpers/is_android';
 
 // tslint:disable-next-line: no-expression-statement
 YellowBox.ignoreWarnings([
@@ -26,10 +24,6 @@ setUrl(API_URL);
 const saga = buildSaga();
 const store = buildStore(saga);
 startApplication(saga, store); // tslint:disable-line:no-expression-statement
-if (isAndroid()) {
-    setStatusBarBackgroundColor('#00000088', false);
-}
-setStatusBarStyle('light');
 
 export const Application = (): JSX.Element => (
     <ErrorBoundary>

--- a/src/application/index.tsx
+++ b/src/application/index.tsx
@@ -6,10 +6,11 @@ import { buildStore, startApplication } from './store';
 import { ErrorBoundary } from './helpers/error_boundary';
 import { ConnectedI18nProvider } from '../components/i18n_provider';
 import { buildSaga } from '../sagas';
-
 import { API_URL } from 'react-native-dotenv';
 import { setUrl } from '../api';
 import {YellowBox} from 'react-native';
+import { setStatusBarBackgroundColor, setStatusBarStyle } from 'expo-status-bar';
+import { isAndroid } from './helpers/is_android';
 
 // tslint:disable-next-line: no-expression-statement
 YellowBox.ignoreWarnings([
@@ -25,6 +26,10 @@ setUrl(API_URL);
 const saga = buildSaga();
 const store = buildStore(saga);
 startApplication(saga, store); // tslint:disable-line:no-expression-statement
+if (isAndroid()) {
+    setStatusBarBackgroundColor('#00000088', false);
+}
+setStatusBarStyle('light');
 
 export const Application = (): JSX.Element => (
     <ErrorBoundary>

--- a/src/application/styles.ts
+++ b/src/application/styles.ts
@@ -29,6 +29,7 @@ export const colors = {
     sunshine: '#f2b134',
     topaz: '#11cac0',
     greyBorder: '#dedede',
+    transparentBlack: '#00000088',
 };
 
 export const values = {

--- a/src/application/styles.ts
+++ b/src/application/styles.ts
@@ -29,7 +29,6 @@ export const colors = {
     sunshine: '#f2b134',
     topaz: '#11cac0',
     greyBorder: '#dedede',
-    transparentBlack: '#00000088',
 };
 
 export const values = {

--- a/src/components/feedback/contact_information_component.tsx
+++ b/src/components/feedback/contact_information_component.tsx
@@ -128,7 +128,7 @@ interface HeaderProps {
 
 const HeaderComponent = ({ feedbackType, onBackButtonPress }: HeaderProps): JSX.Element => {
     return (
-        <Header style={otherRemoveServiceStyles.headerContainer}>
+        <Header style={otherRemoveServiceStyles.headerContainer} androidStatusBarColor={colors.transparentBlack}>
                 <Button transparent onPress={onBackButtonPress}>
                     <Icon name={getIconForBackButton()} style={{ color: colors.teal, fontWeight: 'bold' }} />
                 </Button>

--- a/src/components/feedback/contact_information_component.tsx
+++ b/src/components/feedback/contact_information_component.tsx
@@ -128,7 +128,7 @@ interface HeaderProps {
 
 const HeaderComponent = ({ feedbackType, onBackButtonPress }: HeaderProps): JSX.Element => {
     return (
-        <Header style={otherRemoveServiceStyles.headerContainer} androidStatusBarColor={colors.transparentBlack}>
+        <Header style={otherRemoveServiceStyles.headerContainer} androidStatusBarColor={colors.teal}>
                 <Button transparent onPress={onBackButtonPress}>
                     <Icon name={getIconForBackButton()} style={{ color: colors.teal, fontWeight: 'bold' }} />
                 </Button>

--- a/src/components/feedback/header_component.tsx
+++ b/src/components/feedback/header_component.tsx
@@ -11,7 +11,7 @@ type HeaderProps = {
 };
 
 export const HeaderComponent = ({ headerLabel, close }: HeaderProps): JSX.Element => (
-    <Header style={ styles.headerContainer } androidStatusBarColor={colors.transparentBlack}>
+    <Header style={ styles.headerContainer } androidStatusBarColor={colors.teal}>
         <Text style={[textStyles.headline6, { paddingHorizontal: 15 }]}>
             <Trans id={headerLabel} />
         </Text>

--- a/src/components/feedback/header_component.tsx
+++ b/src/components/feedback/header_component.tsx
@@ -11,7 +11,7 @@ type HeaderProps = {
 };
 
 export const HeaderComponent = ({ headerLabel, close }: HeaderProps): JSX.Element => (
-    <Header style={ styles.headerContainer }>
+    <Header style={ styles.headerContainer } androidStatusBarColor={colors.transparentBlack}>
         <Text style={[textStyles.headline6, { paddingHorizontal: 15 }]}>
             <Trans id={headerLabel} />
         </Text>

--- a/src/components/header_menu/header_menu_component.tsx
+++ b/src/components/header_menu/header_menu_component.tsx
@@ -41,7 +41,7 @@ export const HeaderMenuComponent = (props: Props): JSX.Element => (
                 alignItems: 'center',
                 justifyContent: 'flex-start',
             }}
-            androidStatusBarColor={colors.transparentBlack}
+            androidStatusBarColor={colors.teal}
         >
             <Image source={arrivalAdvisorGlyphLogo} style={{ height: 24, width: 24, marginHorizontal: 10 }} />
             <Title style={textStyles.headlineH3StyleWhiteCenter}>Arrival Advisor</Title>

--- a/src/components/header_menu/header_menu_component.tsx
+++ b/src/components/header_menu/header_menu_component.tsx
@@ -34,7 +34,15 @@ type Props = OwnProps & HeaderMenuProps & HeaderMenuActions;
 
 export const HeaderMenuComponent = (props: Props): JSX.Element => (
     <View style={{ flex: 1, backgroundColor: getViewBackgroundColorForPlatform() }}>
-        <Header style={{ backgroundColor: colors.lightTeal, marginTop: getStatusBarHeightForPlatform(), alignItems: 'center', justifyContent: 'flex-start' }}>
+        <Header
+            style={{
+                backgroundColor: colors.lightTeal,
+                marginTop: getStatusBarHeightForPlatform(),
+                alignItems: 'center',
+                justifyContent: 'flex-start',
+            }}
+            androidStatusBarColor={colors.transparentBlack}
+        >
             <Image source={arrivalAdvisorGlyphLogo} style={{ height: 24, width: 24, marginHorizontal: 10 }} />
             <Title style={textStyles.headlineH3StyleWhiteCenter}>Arrival Advisor</Title>
         </Header>

--- a/src/components/main/header_component.tsx
+++ b/src/components/main/header_component.tsx
@@ -13,7 +13,7 @@ interface HeaderComponentProps {
 }
 
 export const HeaderComponent = (props: HeaderComponentProps): JSX.Element => (
-    <Header style={[ applicationStyles.header, { backgroundColor: props.backgroundColor }]} androidStatusBarColor={colors.transparentBlack}>
+    <Header style={[ applicationStyles.header, { backgroundColor: props.backgroundColor }]} androidStatusBarColor={colors.teal}>
         {buildLeftButton(props.leftButton)}
         {buildTitle(props.title)}
         {buildRightButtons(props.rightButtons)}

--- a/src/components/main/header_component.tsx
+++ b/src/components/main/header_component.tsx
@@ -3,7 +3,7 @@ import { View } from 'react-native';
 import { Header, Left, Right, Body, Title } from 'native-base';
 import { EmptyComponent } from '../empty_component/empty_component';
 import { mapWithIndex } from '../../application/helpers/map_with_index';
-import { applicationStyles } from '../../application/styles';
+import { applicationStyles, colors } from '../../application/styles';
 
 interface HeaderComponentProps {
     readonly backgroundColor: string;
@@ -13,7 +13,7 @@ interface HeaderComponentProps {
 }
 
 export const HeaderComponent = (props: HeaderComponentProps): JSX.Element => (
-    <Header style={[ applicationStyles.header, { backgroundColor: props.backgroundColor }]}>
+    <Header style={[ applicationStyles.header, { backgroundColor: props.backgroundColor }]} androidStatusBarColor={colors.transparentBlack}>
         {buildLeftButton(props.leftButton)}
         {buildTitle(props.title)}
         {buildRightButtons(props.rightButtons)}

--- a/src/components/main/main_component.tsx
+++ b/src/components/main/main_component.tsx
@@ -1,6 +1,6 @@
 // tslint:disable:no-expression-statement
 import React, { useEffect, EffectCallback } from 'react';
-import { StatusBar } from 'react-native';
+import { StatusBar } from 'expo-status-bar';
 import Animated from 'react-native-reanimated';
 import { Container, Drawer, Root } from 'native-base';
 import { MainPageSwitcherComponent } from './main_page_switcher';
@@ -90,7 +90,7 @@ export const MainComponent = (props: Props): JSX.Element => {
 
     return (
         <Root>
-            <StatusBar translucent={true} />
+            <StatusBar />
             <Drawer
                 side='right'
                 onClose={props.closeHeaderMenu}

--- a/src/components/main/main_component.tsx
+++ b/src/components/main/main_component.tsx
@@ -90,7 +90,7 @@ export const MainComponent = (props: Props): JSX.Element => {
 
     return (
         <Root>
-            <StatusBar />
+            <StatusBar style='light'/>
             <Drawer
                 side='right'
                 onClose={props.closeHeaderMenu}

--- a/src/components/search/search_component.tsx
+++ b/src/components/search/search_component.tsx
@@ -165,7 +165,7 @@ const SearchComponentHeader = (props: { readonly onMenuButtonPress: () => void }
 
     return (
         <Animated.View style={{ height: animatedHeaderHeight }}>
-            <Header style={[applicationStyles.header, { backgroundColor: colors.teal }]} androidStatusBarColor={colors.transparentBlack}>
+            <Header style={[applicationStyles.header, { backgroundColor: colors.teal }]} androidStatusBarColor={colors.teal}>
                 <HeaderLeft />
                 <HeaderRight onMenuButtonPress={props.onMenuButtonPress} />
             </Header>

--- a/src/components/search/search_component.tsx
+++ b/src/components/search/search_component.tsx
@@ -165,7 +165,7 @@ const SearchComponentHeader = (props: { readonly onMenuButtonPress: () => void }
 
     return (
         <Animated.View style={{ height: animatedHeaderHeight }}>
-            <Header style={[applicationStyles.header, { backgroundColor: colors.teal }]}>
+            <Header style={[applicationStyles.header, { backgroundColor: colors.teal }]} androidStatusBarColor={colors.transparentBlack}>
                 <HeaderLeft />
                 <HeaderRight onMenuButtonPress={props.onMenuButtonPress} />
             </Header>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4850,6 +4850,11 @@ expo-sqlite@~8.2.1:
     "@expo/websql" "^1.0.1"
     lodash "^4.17.15"
 
+expo-status-bar@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/expo-status-bar/-/expo-status-bar-1.0.2.tgz#2441a77c56be31597898337b0d086981f2adefd8"
+  integrity sha512-5313u744GcLzCadxIPXyTkYw77++UXv1dXCuhYDxDbtsEf93iMra7WSvzyE8a7mRQLIIPRuGnBOdrL/V1C7EOQ==
+
 expo@^38.0.0:
   version "38.0.8"
   resolved "https://registry.yarnpkg.com/expo/-/expo-38.0.8.tgz#c85727eb382d51d8a8289bc669257b1c90472406"


### PR DESCRIPTION
It has been solved. Turns out native-base's `Header` component has a `androidStatusBarColor` property that was overwriting all of our changes to the `StatusBar`. We never used this property in our HeaderComponents so it was turning our bars purple with our knowing.

Please test this PR on your Android device as setting the backgroundColour only applies to them. We should no longer see a purple bar.