### PR TITLE
Issue #1263 feedback header cuts off

### DIFF
--- a/src/components/feedback/header_component.tsx
+++ b/src/components/feedback/header_component.tsx
@@ -4,6 +4,7 @@ import { Header, Text } from 'native-base';
 import { CloseButtonComponent } from '../close_button_component';
 import { colors, textStyles } from '../../application/styles';
 import { otherRemoveServiceStyles as styles } from './styles';
+import { View } from 'react-native';
 
 type HeaderProps = {
     readonly headerLabel: TemplateStringsArray;
@@ -12,9 +13,11 @@ type HeaderProps = {
 
 export const HeaderComponent = ({ headerLabel, close }: HeaderProps): JSX.Element => (
     <Header style={ styles.headerContainer } androidStatusBarColor={colors.teal}>
-        <Text style={[textStyles.headline6, { paddingHorizontal: 15 }]}>
-            <Trans id={headerLabel} />
-        </Text>
+        <View style={{ flex: 4, paddingHorizontal: 15 }}>
+            <Text style={textStyles.headline6}>
+                <Trans id={headerLabel} />
+            </Text>
+        </View>
         <CloseButtonComponent
             color={colors.greyishBrown}
             additionalStyle={{ paddingTop: 0 }}


### PR DESCRIPTION
If you do not see translated feedback strings follow the Steps for QA for Developers [here](https://github.com/pg-irc/pathways-frontend/issues/1263).

The idea for `flex: 4` comes from this thread: https://github.com/GeekyAnts/NativeBase/issues/567 